### PR TITLE
Add attach test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,8 +1510,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1532,14 +1531,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1554,20 +1551,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1684,8 +1678,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1697,7 +1690,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1712,7 +1704,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1720,14 +1711,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1746,7 +1735,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1827,8 +1815,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1840,7 +1827,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1926,8 +1912,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1963,7 +1948,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1983,7 +1967,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2027,14 +2010,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2812,6 +2793,26 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "mocha-jenkins-reporter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.1.tgz",
+      "integrity": "sha512-IqnIylrkKJG0lxeoawRkhv/uiYojMEw3o9TQOpDFarPYKVq4ymngVPwsyfMB0XMDqtDbOTOCviFg8xOLHb80/Q==",
+      "dev": true,
+      "requires": {
+        "diff": "1.0.7",
+        "mkdirp": "0.5.1",
+        "mocha": "^5.2.0",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+          "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+          "dev": true
         }
       }
     },
@@ -4321,6 +4322,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
     "xregexp": {

--- a/src/integration-tests/attach.spec.ts
+++ b/src/integration-tests/attach.spec.ts
@@ -1,0 +1,58 @@
+/*********************************************************************
+ * Copyright (c) 2018 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import { DebugClient } from 'vscode-debugadapter-testsupport/lib/debugClient';
+import { emptyProgram, expectError, sleepProgram, standardBefore, standardBeforeEach } from './utils';
+import { expect } from 'chai';
+import * as cp from 'child_process';
+
+let dc: DebugClient;
+
+before(function () {
+    standardBefore();
+});
+
+beforeEach(async function() {
+    dc = await standardBeforeEach();
+});
+
+after(function() {
+    dc.stop();
+});
+
+describe('attach', function() {
+    // Move the timeout out of the way if the adapter is going to be debugged.
+    if (process.env.INSPECT_DEBUG_ADAPTER) {
+        this.timeout(9999999);
+    }
+
+    it('can attach', async function() {
+        const proc = cp.spawn(sleepProgram);
+        expect(proc.pid).not.eq(undefined);
+
+        await dc.attachRequest({
+            verbose: true,
+            program: sleepProgram,
+            processId: proc.pid,
+        } as any);
+    });
+
+    it('reports an error when attaching to a non-existent pid', async function() {
+        // This should be an invalid pid on most systems...
+        const pid = 666666;
+        const errorAttach = await expectError(dc.attachRequest({
+            verbose: true,
+            program: emptyProgram,
+            processId: pid,
+        } as any));
+
+        expect(errorAttach.message).eq('ptrace: No such process.');
+    });
+});

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -9,34 +9,20 @@
  *********************************************************************/
 
 import { expect } from 'chai';
-import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
-import { getExecPath } from '..';
-
-// Allow non-arrow functions: https://mochajs.org/#arrow-functions
-// tslint:disable:only-arrow-functions
+import { standardBefore, standardBeforeEach } from './utils';
 
 let dc: DebugClient;
 const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
 const emptyProgram = path.join(testProgramsDir, 'empty');
 
 before(function() {
-    // Build the test program
-    cp.execSync('make', { cwd: testProgramsDir });
+    standardBefore();
 });
 
 beforeEach(async function() {
-    let args: string = getExecPath();
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-
-    dc = new DebugClient('node', args, 'cppdbg', {
-        shell: true,
-    });
-    await dc.start();
-    await dc.initializeRequest();
+    dc = await standardBeforeEach();
 });
 
 afterEach(async function() {

--- a/src/integration-tests/test-programs/.gitignore
+++ b/src/integration-tests/test-programs/.gitignore
@@ -1,2 +1,3 @@
 empty
+sleep
 *.o

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -1,4 +1,4 @@
-BINS = empty
+BINS = empty sleep
 
 .PHONY: all
 all: $(BINS)
@@ -7,6 +7,9 @@ CC = gcc
 LINK = $(CC) -o $@ $^
 
 empty: empty.o
+	$(LINK)
+
+sleep: sleep.o
 	$(LINK)
 
 %.o: %.c

--- a/src/integration-tests/test-programs/sleep.c
+++ b/src/integration-tests/test-programs/sleep.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int main()
+{
+        sleep(30);
+	return 0;
+}

--- a/src/integration-tests/tslint.json
+++ b/src/integration-tests/tslint.json
@@ -1,0 +1,6 @@
+// Allow non-arrow functions: https://mochajs.org/#arrow-functions
+{
+  "rules": {
+    "only-arrow-functions": false
+  }
+}

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Copyright (c) 2018 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import { DebugClient } from 'vscode-debugadapter-testsupport/lib/debugClient';
+import { getExecPath } from '..';
+
+export const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
+export const emptyProgram = path.join(testProgramsDir, 'empty');
+export const sleepProgram = path.join(testProgramsDir, 'sleep');
+
+export function standardBefore(): void {
+    // Build the test program
+    cp.execSync('make', { cwd: testProgramsDir });
+}
+
+export async function standardBeforeEach(): Promise<DebugClient> {
+    let args: string = getExecPath();
+    if (process.env.INSPECT_DEBUG_ADAPTER) {
+        args = '--inspect-brk ' + args;
+    }
+
+    const dc = new DebugClient('node', args, 'cppdbg', { shell: true });
+
+    await dc.start();
+    await dc.initializeRequest();
+
+    return dc;
+}
+
+/**
+ * Wrap `promise` in a new Promise that resolves if `promise` is rejected, and is rejected if `promise` is resolved.
+ *
+ * This is useful when we expect `promise` to be reject and was to test that it is indeed the case.
+ */
+export function expectError<T>(promise: Promise<T>): Promise<Error> {
+    return new Promise<Error>((resolve, reject) => {
+        promise.then(reject).catch(resolve);
+    });
+}


### PR DESCRIPTION
Add some simple "attach" tests, one when we successfully attach and one
when we provide a non-existent pid.

I kept it really simple, because I don't yet know what is the right
behavior we should test for.  For example, if the client sends a
configurationDone after a failed attach request, what should we reply?
So the tests can be improved at a later point.

I started to move things out of the existing test to a shared library of
test utilities.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>