### PR TITLE
Add logging with bunyan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/bunyan": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.5.tgz",
+      "integrity": "sha512-7n8ANtxh2c5A/NfCuv8cVtWcgSLdq76MQbtmbInpzXuPw4TSAReUJ+MGHK4m67I4zI3ynCJoABfaeHYJaYSeRg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -420,8 +429,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -512,7 +520,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -664,6 +671,17 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "cacache": {
       "version": "10.0.4",
@@ -881,8 +899,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1124,6 +1141,15 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "dtrace-provider": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
     },
     "duplexify": {
       "version": "3.6.1",
@@ -1510,8 +1536,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1532,14 +1557,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1554,20 +1577,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1684,8 +1704,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1697,7 +1716,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1712,7 +1730,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1720,14 +1737,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1746,7 +1761,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1827,8 +1841,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1840,7 +1853,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1926,8 +1938,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1963,7 +1974,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1983,7 +1993,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2027,14 +2036,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2305,7 +2312,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2314,8 +2320,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
       "version": "1.1.0",
@@ -2699,7 +2704,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2815,6 +2819,26 @@
         }
       }
     },
+    "mocha-jenkins-reporter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.1.tgz",
+      "integrity": "sha512-IqnIylrkKJG0lxeoawRkhv/uiYojMEw3o9TQOpDFarPYKVq4ymngVPwsyfMB0XMDqtDbOTOCviFg8xOLHb80/Q==",
+      "dev": true,
+      "requires": {
+        "diff": "1.0.7",
+        "mkdirp": "0.5.1",
+        "mocha": "^5.2.0",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+          "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+          "dev": true
+        }
+      }
+    },
     "mock-require": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
@@ -2823,6 +2847,12 @@
       "requires": {
         "caller-id": "^0.1.0"
       }
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "optional": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -2844,11 +2874,45 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -2869,6 +2933,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "neo-async": {
       "version": "2.6.0",
@@ -2998,7 +3068,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3119,8 +3188,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -3411,6 +3479,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4320,7 +4394,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   },
   "homepage": "https://github.com/eclipse-cdt/cdt-gdb-adapter#readme",
   "dependencies": {
-    "vscode-debugadapter": "^1.32.1"
+    "vscode-debugadapter": "^1.32.1",
+    "bunyan": "^1.8.12"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.5",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.2",

--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -10,8 +10,8 @@
 import { spawn } from 'child_process';
 import * as events from 'events';
 import { Writable } from 'stream';
-import { logger } from 'vscode-debugadapter/lib/logger';
 import { AttachRequestArguments, LaunchRequestArguments } from './GDBDebugSession';
+import { logger } from './logging';
 import { MIParser } from './MIParser';
 
 export interface MIResponse {
@@ -62,7 +62,7 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendCommand<T>(command: string): Promise<T> {
         const token = this.nextToken();
-        logger.verbose(`GDB command: ${token} ${command}`);
+        logger.debug('GDB command', token, command);
         return new Promise<T>((resolve, reject) => {
             if (this.out) {
                 this.parser.queueCommand(token, (result) => {

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 import { Readable } from 'stream';
-import { logger } from 'vscode-debugadapter/lib/logger';
 import { GDBBackend } from './GDBBackend';
+import { logger } from './logging';
 
 export class MIParser {
     private line = '';
@@ -213,7 +213,7 @@ export class MIParser {
     private handleLogStream() {
         const msg = this.handleCString();
         if (msg) {
-            logger.log(msg);
+            logger.info(msg);
         }
     }
 
@@ -232,14 +232,14 @@ export class MIParser {
 
         switch (c) {
             case '^':
-                logger.verbose('GDB result: ' + this.restOfLine());
+                logger.debug('GDB result', this.restOfLine());
                 const command = this.commandQueue[token];
                 if (command) {
                     const asyncResult = this.handleAsyncOutput();
                     command(asyncResult);
                     delete this.commandQueue[token];
                 } else {
-                    logger.error('GDB response with no command: ' + token);
+                    logger.error('GDB response with no command', token);
                 }
                 break;
             case '~':
@@ -251,10 +251,10 @@ export class MIParser {
                 break;
             case '=':
                 // TODO: notify
-                logger.verbose('GDB notify: ' + this.restOfLine());
+                logger.debug('GDB notify', this.restOfLine());
                 break;
             case '*':
-                logger.verbose('GDB async: ' + this.restOfLine());
+                logger.debug('GDB async', this.restOfLine());
                 const result = this.handleAsyncOutput();
                 this.gdb.emit('async', result);
                 break;

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 import * as process from 'process';
-import { logger } from 'vscode-debugadapter/lib/logger';
 import { GDBDebugSession } from './GDBDebugSession';
+import { logger } from './logging';
 
 process.on('uncaughtException', (err: any) => {
-    logger.error(JSON.stringify(err));
+    logger.error('Uncaught exception', err);
 });
 
 GDBDebugSession.run(GDBDebugSession);

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -49,7 +49,6 @@ describe('launch', function() {
 
     it('can launch and hit a breakpoint', async function() {
         await dc.launchRequest({
-            verbose: true,
             program: emptyProgram,
         } as any);
 
@@ -66,7 +65,6 @@ describe('launch', function() {
     it('reports an error when specifying a non-existent binary', async function() {
         const errorMessage = await new Promise<Error>((resolve, reject) => {
             dc.launchRequest({
-                verbose: true,
                 program: '/does/not/exist',
             } as any)
                 .then(reject)

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,34 @@
+/*********************************************************************
+ * Copyright (c) 2018 Ercisson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as bunyan from 'bunyan';
+
+/**
+ * Global logger for the debug adapter.
+ */
+export const logger = bunyan.createLogger({
+    name: 'debugadapter',
+    streams: [{
+        stream: process.stderr,
+        level: 'warn',
+    }],
+});
+
+/**
+ * Add a file output stream to the global logger.  The level of that new stream is `debug`.
+ *
+ * @param logFile path to the output file
+ */
+export function addLogFile(logFile: string): void {
+    logger.addStream({
+        path: logFile,
+        level: 'debug',
+    });
+}

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
       "elements"
     ],
     "interface-name": false,
+    "member-ordering": false,
     "no-empty-interface": false,
     "object-literal-sort-keys": false,
     "quotemark": [


### PR DESCRIPTION
The GDBDebugSession class currently inherits from LoggingDebugSession
(from vscode-debugadapter), but I am pretty sure logging is not
functional.  In particular, we pass it a relative file name, but the
logger code requires it to be absolute:

    https://github.com/Microsoft/vscode-debugadapter-node/blob/ac2d3a31cf5e71999e28c191f0b80a56439954bc/adapter/src/logger.ts#L144

Therefore I conclude it's not used at the moment.

Instead of using LoggingDebugSession, which is quite rudimentary, I
suggest using a dedicated logging library.  This will give us a bit more
control on what we log, where it goes, etc.  I have tried winston and
bunyan, two popular libraries, but got better and easier results with
the bunyan, so I went with that.

With this patch, there is a default stream to stderr which shows
warnings and above.  Passing `logFile` in a launch request enables a log
file with levels `debug` and above to be written, with all the DA and MI
communications.

Note that the logs are written as json files, and the `bunyan` CLI tool
can be used to display them nicely,

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>