### PR TITLE
Adjust rules to add space before parentheses of anonymous function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+  "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false
 }

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -25,7 +25,7 @@ const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tes
 const varsProgram = path.join(testProgramsDir, 'vars');
 const varsSrc = path.join(testProgramsDir, 'vars.c');
 
-beforeEach(async function () {
+beforeEach(async function() {
     // Build the test program
     cp.execSync('make', { cwd: testProgramsDir });
 
@@ -48,16 +48,16 @@ beforeEach(async function () {
     expect(scopes.body.scopes.length).to.equal(1);
 });
 
-afterEach(async function () {
+afterEach(async function() {
     await dc.stop();
 });
 
-describe('Variables Test Suite', function () {
+describe('Variables Test Suite', function() {
     // Move the timeout out of the way if the adapter is going to be debugged.
     if (process.env.INSPECT_DEBUG_ADAPTER) {
         this.timeout(9999999);
     }
-    it('can read variables from a program', async function () {
+    it('can read variables from a program', async function() {
         const vars = await dc.variablesRequest({ variablesReference: scopes.body.scopes[0].variablesReference });
         expect(vars.body.variables.length).to.equal(3);
         expect(vars.body.variables[0].name).to.equal('a');
@@ -66,7 +66,7 @@ describe('Variables Test Suite', function () {
         expect(vars.body.variables[1].value).to.equal('2');
     });
 
-    it('can set variables in a program', async function () {
+    it('can set variables in a program', async function() {
         const vr = scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length).to.equal(3);

--- a/tsfmt.json
+++ b/tsfmt.json
@@ -1,0 +1,3 @@
+{
+  "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false
+}

--- a/tslint.json
+++ b/tslint.json
@@ -18,6 +18,12 @@
       "single",
       "avoid-template",
       "avoid-escape"
+    ],
+    "space-before-function-paren": [
+      true,
+      {
+        "anonymous": "never"
+      }
     ]
   }
 }


### PR DESCRIPTION
By default, Theia (typescript-language-server, in fact) and VSCode don't
auto-format anonymous functions the same way:

    Theia:  function() {
    VSCode: function () {

I don't really mind which one we use, I just want it to be consistent
and avoid spurious diffs when reformating.  I chose the VSCode way.

This patch adds a tsfmt.json file, which typescript-language-server
reads.  It also adjusts the tslint rule to match, and fixes all
offenders.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>