### PR TITLE
Add source map support when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "yarn test:integration && yarn test:pty && yarn test:integration --run-in-terminal",
-    "test:integration": "mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
-    "test:pty": "mocha --reporter mocha-jenkins-reporter dist/native/*.spec.js"
+    "test:integration": "mocha --require source-map-support/register dist --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
+    "test:pty": "mocha --require source-map-support/register dist --reporter mocha-jenkins-reporter dist/native/*.spec.js"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.1",
     "node-gyp": "^3.8.0",
+    "source-map-support": "^0.5.10",
     "ts-loader": "^5.3.0",
     "tslint": "^5.11.0",
     "tslint-language-service": "^0.9.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2828,6 +2828,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
+  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"


### PR DESCRIPTION
Currently, when we have a test failure, we get a js backtrace:

      at Context.<anonymous> (dist/integration-tests/var.spec.js:71:60)
      at Generator.next (<anonymous>)
      at fulfilled (dist/integration-tests/var.spec.js:13:58)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)

With this patch, mocha makes use of the source maps to show the locations in
the original source files:

      at Context.<anonymous> (src/integration-tests/var.spec.ts:64:49)
      at Generator.next (<anonymous>)
      at fulfilled (dist/integration-tests/var.spec.js:13:58)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:189:7)