### PR TITLE
Include token number is GDB results

### DIFF
--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -230,7 +230,7 @@ export class MIParser {
 
         switch (c) {
             case '^':
-                logger.verbose('GDB result: ' + this.restOfLine());
+                logger.verbose(`GDB result: ${token} ${this.restOfLine()}`);
                 const command = this.commandQueue[token];
                 if (command) {
                     const resultClass = this.handleString();


### PR DESCRIPTION
On some commands, e.g. target remote, there can be a big gap between
the GDB command being issued and the result, by printing the token
with the result it makes it easier to line up the log.