### PR TITLE
Memory references in variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write .",
+    "format-check": "prettier --check .",
     "clean": "git clean -dfx",
     "docker:build": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn",
     "docker:test": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn test",

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1289,17 +1289,21 @@ export class GDBDebugSession extends LoggingDebugSession {
         args: DebugProtocol.ReadMemoryArguments
     ): Promise<void> {
         try {
-            const result = await sendDataReadMemoryBytes(
-                this.gdb,
-                args.memoryReference,
-                args.count,
-                args.offset
-            );
-            response.body = {
-                data: hexToBase64(result.memory[0].contents),
-                address: result.memory[0].begin,
-            };
-            this.sendResponse(response);
+            if (args.count) {
+                const result = await sendDataReadMemoryBytes(
+                    this.gdb,
+                    args.memoryReference,
+                    args.count,
+                    args.offset
+                );
+                response.body = {
+                    data: hexToBase64(result.memory[0].contents),
+                    address: result.memory[0].begin,
+                };
+                this.sendResponse(response);
+            } else {
+                this.sendResponse(response);
+            }
         } catch (err) {
             this.sendErrorResponse(
                 response,

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1552,6 +1552,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                             name: varobj.expression,
                             value,
                             type: varobj.type,
+                            memoryReference: `&(${varobj.expression})`,
                             variablesReference:
                                 parseInt(varobj.numchild, 10) > 0
                                     ? this.variableHandles.create({
@@ -1622,6 +1623,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                     name: varobj.expression,
                     value,
                     type: varobj.type,
+                    memoryReference: `&(${varobj.expression})`,
                     variablesReference:
                         parseInt(varobj.numchild, 10) > 0
                             ? this.variableHandles.create({

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -228,6 +228,18 @@ export class CdtDebugClient extends DebugClient {
             `Content-Length: ${Buffer.byteLength(json, 'utf-8')}\r\n\r\n${json}`
         );
     }
+
+    public readMemoryRequest(
+        args: DebugProtocol.ReadMemoryArguments
+    ): Promise<DebugProtocol.ReadMemoryResponse> {
+        return this.send('readMemory', args);
+    }
+
+    public writeMemoryRequest(
+        args: DebugProtocol.WriteMemoryArguments
+    ): Promise<DebugProtocol.WriteMemoryResponse> {
+        return this.send('writeMemory', args);
+    }
 }
 
 /**

--- a/src/integration-tests/mem-cdt-custom.spec.ts
+++ b/src/integration-tests/mem-cdt-custom.spec.ts
@@ -1,0 +1,154 @@
+/*********************************************************************
+ * Copyright (c) 2018, 2022 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import { expect } from 'chai';
+import * as path from 'path';
+import { DebugProtocol } from '@vscode/debugprotocol/lib/debugProtocol';
+import { LaunchRequestArguments, MemoryResponse } from '../GDBDebugSession';
+import { CdtDebugClient } from './debugClient';
+import {
+    expectRejection,
+    gdbPath,
+    openGdbConsole,
+    standardBeforeEach,
+    testProgramsDir,
+} from './utils';
+
+describe('Memory Test Suite for cdt-gdb-adapter/Memory custom request', function () {
+    let dc: CdtDebugClient;
+    let frame: DebugProtocol.StackFrame;
+    const memProgram = path.join(testProgramsDir, 'mem');
+    const memSrc = path.join(testProgramsDir, 'mem.c');
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach();
+
+        await dc.hitBreakpoint(
+            {
+                gdb: gdbPath,
+                program: memProgram,
+                openGdbConsole,
+            } as LaunchRequestArguments,
+            {
+                path: memSrc,
+                line: 12,
+            }
+        );
+        const threads = await dc.threadsRequest();
+        // On windows additional threads can exist to handle signals, therefore find
+        // the real thread & frame running the user code. The other thread will
+        // normally be running code from ntdll or similar.
+        loop_threads: for (const thread of threads.body.threads) {
+            const stack = await dc.stackTraceRequest({ threadId: thread.id });
+            if (stack.body.stackFrames.length >= 1) {
+                for (const f of stack.body.stackFrames) {
+                    if (f.source && f.source.name === 'mem.c') {
+                        frame = f;
+                        break loop_threads;
+                    }
+                }
+            }
+        }
+        // Make sure we found the expected frame
+        expect(frame).not.eq(undefined);
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    /**
+     * Verify that `resp` contains the bytes `expectedBytes` and the
+     * `expectedAddress` start address.
+     *
+     * `expectedAddress` should be an hexadecimal string, with the leading 0x.
+     */
+    function verifyMemoryReadResult(
+        resp: MemoryResponse,
+        expectedBytes: string,
+        expectedAddress: number
+    ) {
+        expect(resp.body.data).eq(expectedBytes);
+        expect(resp.body.address).match(/^0x[0-9a-fA-F]+$/);
+
+        const actualAddress = parseInt(resp.body.address, 16);
+        expect(actualAddress).eq(expectedAddress);
+    }
+
+    // Test reading memory using cdt-gdb-adapter's extension request.
+    it('can read memory', async function () {
+        // Get the address of the array.
+        const addrOfArrayResp = await dc.evaluateRequest({
+            expression: '&array',
+            frameId: frame.id,
+        });
+        const addrOfArray = parseInt(addrOfArrayResp.body.result, 16);
+
+        let mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: '0x' + addrOfArray.toString(16),
+            length: 10,
+        })) as MemoryResponse;
+
+        verifyMemoryReadResult(mem, 'f1efd4fd7248450c2d13', addrOfArray);
+
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: '&array[3 + 2]',
+            length: 10,
+        })) as MemoryResponse;
+
+        verifyMemoryReadResult(mem, '48450c2d1374d6f612dc', addrOfArray + 5);
+
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: 'parray',
+            length: 10,
+        })) as MemoryResponse;
+
+        verifyMemoryReadResult(mem, 'f1efd4fd7248450c2d13', addrOfArray);
+    });
+
+    it('handles unable to read memory', async function () {
+        // This test will only work for targets for which address 0 is not readable, which is good enough for now.
+        const err = await expectRejection(
+            dc.send('cdt-gdb-adapter/Memory', {
+                address: '0',
+                length: 10,
+            })
+        );
+        expect(err.message).contains('Unable to read memory');
+    });
+
+    it('can read memory with offset', async function () {
+        const addrOfArrayResp = await dc.evaluateRequest({
+            expression: '&array',
+            frameId: frame.id,
+        });
+        const addrOfArray = parseInt(addrOfArrayResp.body.result, 16);
+
+        // Test positive offset
+        let offset = 5;
+        let mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: '&array',
+            length: 5,
+            offset,
+        })) as MemoryResponse;
+
+        verifyMemoryReadResult(mem, '48450c2d13', addrOfArray + offset);
+
+        // Test negative offset
+        offset = -5;
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: `array + ${-offset}`,
+            length: 10,
+            offset,
+        })) as MemoryResponse;
+
+        verifyMemoryReadResult(mem, 'f1efd4fd7248450c2d13', addrOfArray);
+    });
+});

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -116,6 +116,31 @@ describe('Memory Test Suite', function () {
         });
 
         verifyReadMemoryResponse(mem, 'f1efd4fd7248450c2d13', addrOfArray);
+
+        mem = await dc.readMemoryRequest({
+            memoryReference: 'parray',
+            count: 10,
+            offset: 5,
+        });
+
+        verifyReadMemoryResponse(mem, '48450c2d1374d6f612dc', addrOfArray + 5);
+
+        mem = await dc.readMemoryRequest({
+            memoryReference: 'parray',
+            count: 0,
+        });
+
+        // the spec isn't clear on what exactly can be retruned if count == 0
+        // so the following works with VSCode - simply having no body
+        expect(mem.body).is.undefined;
+
+        mem = await dc.readMemoryRequest({
+            memoryReference: 'parray',
+            count: 0,
+            offset: 5,
+        });
+
+        expect(mem.body).is.undefined;
     });
 
     it('handles unable to read memory', async function () {

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -65,7 +65,10 @@ export function verifyVariable(
     expectedName: string,
     expectedType?: string,
     expectedValue?: string,
-    hasChildren = false
+    flags?: {
+        hasChildren?: boolean; // default false
+        hasMemoryReference?: boolean; // default true
+    }
 ) {
     expect(variable.name, `The name of ${expectedName} is wrong`).to.equal(
         expectedName
@@ -81,7 +84,7 @@ export function verifyVariable(
             `The value of ${expectedName} is wrong`
         ).to.equal(expectedValue);
     }
-    if (hasChildren) {
+    if (flags?.hasChildren) {
         expect(
             variable.variablesReference,
             `${expectedName} has no children`
@@ -91,6 +94,16 @@ export function verifyVariable(
             variable.variablesReference,
             `${expectedName} has children`
         ).to.equal(0);
+    }
+    if (flags?.hasMemoryReference || flags?.hasMemoryReference === undefined) {
+        // Rather than actual read the memory, just verify that the memory
+        // reference is to what is expected
+        expect(variable.memoryReference).eq(`&(${expectedName})`);
+    } else {
+        // For now we only support memory references for top-level
+        // variables (e.g. no struct members). A possible
+        // TODO is to support memoryReferences in these cases
+        expect(variable.memoryReference).is.undefined;
     }
 }
 

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -140,13 +140,9 @@ describe('Variables Test Suite', function () {
             vars.body.variables.length,
             'There is a different number of variables than expected'
         ).to.equal(numVars);
-        verifyVariable(
-            vars.body.variables[3],
-            'r',
-            'struct foo',
-            '{...}',
-            true
-        );
+        verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', {
+            hasChildren: true,
+        });
         const childVR = vars.body.variables[3].variablesReference;
         let children = await dc.variablesRequest({
             variablesReference: childVR,
@@ -155,15 +151,16 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], 'x', 'int', '1');
-        verifyVariable(children.body.variables[1], 'y', 'int', '2');
-        verifyVariable(
-            children.body.variables[2],
-            'z',
-            'struct bar',
-            '{...}',
-            true
-        );
+        verifyVariable(children.body.variables[0], 'x', 'int', '1', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[1], 'y', 'int', '2', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', {
+            hasChildren: true,
+            hasMemoryReference: false,
+        });
         // set the variables to something different
         await dc.setVariableRequest({
             name: 'x',
@@ -181,8 +178,12 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], 'x', 'int', '25');
-        verifyVariable(children.body.variables[1], 'y', 'int', '10');
+        verifyVariable(children.body.variables[0], 'x', 'int', '25', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[1], 'y', 'int', '10', {
+            hasMemoryReference: false,
+        });
         // step the program and see that the values were passed to the program and evaluated.
         await dc.next(
             { threadId: scope.thread.id },
@@ -224,13 +225,9 @@ describe('Variables Test Suite', function () {
             vars.body.variables.length,
             'There is a different number of variables than expected'
         ).to.equal(numVars);
-        verifyVariable(
-            vars.body.variables[3],
-            'r',
-            'struct foo',
-            '{...}',
-            true
-        );
+        verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', {
+            hasChildren: true,
+        });
         const childVR = vars.body.variables[3].variablesReference;
         const children = await dc.variablesRequest({
             variablesReference: childVR,
@@ -239,13 +236,10 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(
-            children.body.variables[2],
-            'z',
-            'struct bar',
-            '{...}',
-            true
-        );
+        verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', {
+            hasChildren: true,
+            hasMemoryReference: false,
+        });
         // assert we can see the elements of z
         const subChildVR = children.body.variables[2].variablesReference;
         let subChildren = await dc.variablesRequest({
@@ -255,8 +249,12 @@ describe('Variables Test Suite', function () {
             subChildren.body.variables.length,
             'There is a different number of grandchild variables than expected'
         ).to.equal(2);
-        verifyVariable(subChildren.body.variables[0], 'a', 'int', '3');
-        verifyVariable(subChildren.body.variables[1], 'b', 'int', '4');
+        verifyVariable(subChildren.body.variables[0], 'a', 'int', '3', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(subChildren.body.variables[1], 'b', 'int', '4', {
+            hasMemoryReference: false,
+        });
         // set the variables to something different
         await dc.setVariableRequest({
             name: 'a',
@@ -276,8 +274,12 @@ describe('Variables Test Suite', function () {
             subChildren.body.variables.length,
             'There is a different number of grandchild variables than expected'
         ).to.equal(2);
-        verifyVariable(subChildren.body.variables[0], 'a', 'int', '25');
-        verifyVariable(subChildren.body.variables[1], 'b', 'int', '10');
+        verifyVariable(subChildren.body.variables[0], 'a', 'int', '25', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(subChildren.body.variables[1], 'b', 'int', '10', {
+            hasMemoryReference: false,
+        });
         // step the program and see that the values were passed to the program and evaluated.
         await dc.next(
             { threadId: scope.thread.id },
@@ -324,7 +326,9 @@ describe('Variables Test Suite', function () {
             vars.body.variables.length,
             'There is a different number of variables than expected'
         ).to.equal(numVars);
-        verifyVariable(vars.body.variables[6], 'f', 'int [3]', undefined, true);
+        verifyVariable(vars.body.variables[6], 'f', 'int [3]', undefined, {
+            hasChildren: true,
+        });
         expect(
             hexValueRegex.test(vars.body.variables[6].value),
             'The display value of the array is not a hexidecimal address'
@@ -337,9 +341,15 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], '[0]', 'int', '1');
-        verifyVariable(children.body.variables[1], '[1]', 'int', '2');
-        verifyVariable(children.body.variables[2], '[2]', 'int', '3');
+        verifyVariable(children.body.variables[0], '[0]', 'int', '1', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[1], '[1]', 'int', '2', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[2], '[2]', 'int', '3', {
+            hasMemoryReference: false,
+        });
         // set the variables to something different
         await dc.setVariableRequest({
             name: '[0]',
@@ -362,9 +372,15 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], '[0]', 'int', '11');
-        verifyVariable(children.body.variables[1], '[1]', 'int', '22');
-        verifyVariable(children.body.variables[2], '[2]', 'int', '33');
+        verifyVariable(children.body.variables[0], '[0]', 'int', '11', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[1], '[1]', 'int', '22', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[2], '[2]', 'int', '33', {
+            hasMemoryReference: false,
+        });
         // step the program and see that the values were passed to the program and evaluated.
         await dc.next(
             { threadId: scope.thread.id },

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -82,20 +82,12 @@ describe('Variables CPP Test Suite', function () {
             vars.body.variables.length,
             'There is a different number of variables than expected'
         ).to.equal(3);
-        verifyVariable(
-            vars.body.variables[0],
-            'fooA',
-            'Foo *',
-            undefined,
-            true
-        );
-        verifyVariable(
-            vars.body.variables[1],
-            'fooB',
-            'Foo *',
-            undefined,
-            true
-        );
+        verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, {
+            hasChildren: true,
+        });
+        verifyVariable(vars.body.variables[1], 'fooB', 'Foo *', undefined, {
+            hasChildren: true,
+        });
         expect(
             vars.body.variables[0].value,
             'Value of fooA matches fooB'
@@ -189,13 +181,9 @@ describe('Variables CPP Test Suite', function () {
             vars.body.variables.length,
             'There is a different number of variables than expected'
         ).to.equal(3);
-        verifyVariable(
-            vars.body.variables[0],
-            'fooA',
-            'Foo *',
-            undefined,
-            true
-        );
+        verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, {
+            hasChildren: true,
+        });
         expect(
             vars.body.variables[0].variablesReference,
             `${vars.body.variables[0].name} has no children`
@@ -208,9 +196,15 @@ describe('Variables CPP Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], 'a', 'int', '1');
-        verifyVariable(children.body.variables[1], 'c', 'char', "97 'a'");
-        verifyVariable(children.body.variables[2], 'b', 'int', '2');
+        verifyVariable(children.body.variables[0], 'a', 'int', '1', {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[1], 'c', 'char', "97 'a'", {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[2], 'b', 'int', '2', {
+            hasMemoryReference: false,
+        });
         // set child value
         await dc.setVariableRequest({
             name: children.body.variables[0].name,
@@ -225,9 +219,15 @@ describe('Variables CPP Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], 'a', 'int', '55');
+        verifyVariable(children.body.variables[0], 'a', 'int', '55', {
+            hasMemoryReference: false,
+        });
         // these two values should be unchanged.
-        verifyVariable(children.body.variables[1], 'c', 'char', "97 'a'");
-        verifyVariable(children.body.variables[2], 'b', 'int', '2');
+        verifyVariable(children.body.variables[1], 'c', 'char', "97 'a'", {
+            hasMemoryReference: false,
+        });
+        verifyVariable(children.body.variables[2], 'b', 'int', '2', {
+            hasMemoryReference: false,
+        });
     });
 });


### PR DESCRIPTION
Enable view binary data to variables view
    
This commit only supports top level variables (i.e. not members of structures/classes).
    
This supports the new feature in VSCode 1.64: https://code.visualstudio.com/updates/v1_64#_viewing-and-editing-binary-data

This PR includes some cleanup commits and test updates

