### PR TITLE
Add support for older versions of GDB

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -168,15 +168,20 @@ export class GDBBackend extends events.EventEmitter {
     }
 
     // Rewrite the argument escaping whitespace, quotes and backslash
-    public standardEscape(arg: string): string {
+    public standardEscape(arg: string, needQuotes = true): string {
         let result = '';
         for (const char of arg) {
             if (char === '\\' || char === '"') {
                 result += '\\';
             }
+            if (char == ' ') {
+                needQuotes = true;
+            }
             result += char;
         }
-        result = `"${result}"`;
+        if (needQuotes) {
+            result = `"${result}"`;
+        }
         return result;
     }
 

--- a/src/integration-tests/GDBBackend.spec.ts
+++ b/src/integration-tests/GDBBackend.spec.ts
@@ -15,12 +15,12 @@ import { GDBBackend } from '..';
 describe('GDB Backend Test Suite', function () {
     let gdb: GDBBackend;
 
-    beforeEach(function () {
+    beforeEach(async function () {
         gdb = new GDBBackend();
         const args: LaunchRequestArguments = {
             program: 'foo',
         };
-        gdb.spawn(args);
+        await gdb.spawn(args);
     });
 
     afterEach(function () {

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -19,6 +19,7 @@ import {
     openGdbConsole,
     getScopes,
     verifyVariable,
+    gdbVersionAtLeast,
 } from './utils';
 import { DebugProtocol } from '@vscode/debugprotocol';
 
@@ -212,9 +213,11 @@ describe('breakpoints', async () => {
         );
     });
 
-    // Pending support for testing multiple GDB versions - test requires
-    // GDB >= 8.2
-    it.skip('reports back relocated line number', async () => {
+    it('reports back relocated line number', async function () {
+        if (!(await gdbVersionAtLeast('8.2'))) {
+            this.skip();
+        }
+
         const args = {
             source: {
                 name: 'count.c',
@@ -232,9 +235,11 @@ describe('breakpoints', async () => {
         expect(bpResp.body.breakpoints[0].line).eq(6);
     });
 
-    // Pending support for testing multiple GDB versions - test requires
-    // GDB >= 8.2
-    it.skip('maintains gdb breakpoint when relocated', async () => {
+    it('maintains gdb breakpoint when relocated', async function () {
+        if (!(await gdbVersionAtLeast('8.2'))) {
+            this.skip();
+        }
+
         const args = {
             source: {
                 name: 'count.c',
@@ -259,9 +264,11 @@ describe('breakpoints', async () => {
         );
     });
 
-    // Pending support for testing multiple GDB versions - test requires
-    // GDB >= 8.2
-    it.skip('maintains gdb breakpoint when relocated - files with spaces', async () => {
+    it('maintains gdb breakpoint when relocated - files with spaces', async function () {
+        if (!(await gdbVersionAtLeast('8.2'))) {
+            this.skip();
+        }
+
         const args = {
             source: {
                 name: 'count space.c',

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -172,6 +172,46 @@ describe('breakpoints', async () => {
         );
     });
 
+    it('maintains breakpoint order when modifying breakpoints in a file with space', async () => {
+        const bpResp1 = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count space.c',
+                path: path.join(testProgramsDir, 'count space.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 5,
+                },
+            ],
+        });
+        expect(bpResp1.body.breakpoints.length).to.eq(1);
+        expect(bpResp1.body.breakpoints[0].line).eq(5);
+        const bpResp2 = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count space.c',
+                path: path.join(testProgramsDir, 'count space.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 2,
+                },
+                {
+                    column: 1,
+                    line: 5,
+                },
+            ],
+        });
+        expect(bpResp2.body.breakpoints.length).to.eq(2);
+        expect(bpResp2.body.breakpoints[0].line).eq(2);
+        expect(bpResp2.body.breakpoints[1].line).eq(5);
+        // Make sure the GDB id of the breakpoint on line 5 is unchanged
+        expect(bpResp2.body.breakpoints[1].id).eq(
+            bpResp1.body.breakpoints[0].id
+        );
+    });
+
     // Pending support for testing multiple GDB versions - test requires
     // GDB >= 8.2
     it.skip('reports back relocated line number', async () => {

--- a/src/integration-tests/test-programs/count space.c
+++ b/src/integration-tests/test-programs/count space.c
@@ -5,8 +5,8 @@ static int staticfunc2(void) {
     return 2;
 }
 
-int other_space(void) {
-    staticfunc1();
+int other_space(void)
+{    staticfunc1(); // make the line of code the same as opening brace to account for different gdb/gcc combinations
     staticfunc2();
     return 0;
 }

--- a/src/integration-tests/util.spec.ts
+++ b/src/integration-tests/util.spec.ts
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Copyright (c) 2022 Kichwa Coders Canada, Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { compareVersions, parseGdbVersionOutput } from '../util';
+import { expect } from 'chai';
+
+describe('util', async () => {
+    it('compareVersions', async () => {
+        expect(compareVersions('1', '2')).to.eq(-1);
+        expect(compareVersions('2', '1')).to.eq(1);
+        expect(compareVersions('11', '2')).to.eq(1);
+        expect(compareVersions('2', '11')).to.eq(-1);
+        expect(compareVersions('1.0', '2.0')).to.eq(-1);
+        expect(compareVersions('2.0', '1.0')).to.eq(1);
+        expect(compareVersions('1.0', '1.0')).to.eq(0);
+        expect(compareVersions('1', '1.1')).to.eq(-1);
+        expect(compareVersions('1', '0.1')).to.eq(1);
+        expect(compareVersions('1.1', '1')).to.eq(1);
+        expect(compareVersions('0.1', '1')).to.eq(-1);
+        expect(compareVersions('1.0', '1')).to.eq(0);
+        expect(compareVersions('1', '1.0')).to.eq(0);
+        expect(compareVersions('1.asdf.0', '1.cdef.0')).to.eq(0);
+        expect(compareVersions('1.asdf', '1')).to.eq(0);
+        expect(compareVersions('1', '1.asdf')).to.eq(0);
+    });
+    it('parseGdbOutput', async () => {
+        expect(parseGdbVersionOutput('GNU gdb 6.8.50.20080730')).to.eq(
+            '6.8.50.20080730'
+        );
+        expect(
+            parseGdbVersionOutput('GNU gdb (GDB) 6.8.50.20080730-cvs')
+        ).to.eq('6.8.50.20080730');
+        expect(
+            parseGdbVersionOutput(
+                'GNU gdb (Ericsson GDB 1.0-10) 6.8.50.20080730-cvs'
+            )
+        ).to.eq('6.8.50.20080730');
+        expect(
+            parseGdbVersionOutput('GNU gdb (GDB) Fedora (7.0-3.fc12)')
+        ).to.eq('7.0');
+        expect(parseGdbVersionOutput('GNU gdb 7.0')).to.eq('7.0');
+        expect(parseGdbVersionOutput('GNU gdb Fedora (6.8-27.el5)')).to.eq(
+            '6.8'
+        );
+        expect(
+            parseGdbVersionOutput('GNU gdb Red Hat Linux (6.3.0.0-1.162.el4rh)')
+        ).to.eq('6.3.0.0');
+        expect(
+            parseGdbVersionOutput(
+                'GNU gdb (GDB) STMicroelectronics/Linux Base 7.4-71 [build Mar  1 2013]'
+            )
+        ).to.eq('7.4');
+    });
+});

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { CdtDebugClient } from './debugClient';
+import { compareVersions, getGdbVersion } from '../util';
 
 export interface Scope {
     thread: DebugProtocol.Thread;
@@ -229,6 +230,15 @@ function getDefaultAdapterCli(): string {
         return 'debugAdapter.js';
     }
     return 'debugTargetAdapter.js';
+}
+
+export async function gdbVersionAtLeast(
+    targetVersion: string
+): Promise<boolean> {
+    return (
+        compareVersions(await getGdbVersion(gdbPath || 'gdb'), targetVersion) >=
+        0
+    );
 }
 
 export interface LineTags {

--- a/src/mi/data.ts
+++ b/src/mi/data.ts
@@ -77,9 +77,10 @@ export async function sendDataDisassemble(
     endAddress: string
 ): Promise<MIDataDisassembleResponse> {
     // -- 5 == mixed source and disassembly with raw opcodes
-    // TODO needs to be -- 3 for GDB < 7.11 -- are we supporting such old versions?
+    // needs to be deprecated mode 3 for GDB < 7.11
+    const mode = gdb.gdbVersionAtLeast('7.11') ? '5' : '3';
     const result: MIDataDisassembleResponse = await gdb.sendCommand(
-        `-data-disassemble -s "${startAddress}" -e "${endAddress}" -- 5`
+        `-data-disassemble -s "${startAddress}" -e "${endAddress}" -- ${mode}`
     );
 
     // cleanup the result data

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,107 @@
+/*********************************************************************
+ * Copyright (c) 2022 Kichwa Coders Canada, Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+/**
+ * This method actually launches 'gdb --version' to determine the version of
+ * the GDB that is being used.
+ *
+ * @param gdbPath the path to the GDB executable to be called
+ * @return the detected version of GDB at gdbPath
+ */
+export async function getGdbVersion(gdbPath: string): Promise<string> {
+    const { stdout, stderr } = await promisify(execFile)(gdbPath, [
+        '--version',
+    ]);
+
+    const gdbVersion = parseGdbVersionOutput(stdout);
+    if (!gdbVersion) {
+        throw new Error(
+            `Failed to get version number from GDB. GDB returned:\nstdout:\n${stdout}\nstderr:\n${stderr}`
+        );
+    }
+    return gdbVersion;
+}
+
+/**
+ * Find gdb version info from a string object which is supposed to
+ * contain output text of "gdb --version" command.
+ *
+ * @param stdout
+ * 		output text from "gdb --version" command .
+ * @return
+ * 		String representation of version of gdb such as "10.1" on success
+ */
+export function parseGdbVersionOutput(stdout: string): string | undefined {
+    return stdout.split(/ gdb( \(.*?\))? (\D* )*\(?(\d*(\.\d*)*)/g)[3];
+}
+
+/**
+ * Compares two version numbers.
+ * Returns -1, 0, or 1 if v1 is less than, equal to, or greater than v2, respectively.
+ * @param v1 The first version
+ * @param v2 The second version
+ * @return -1, 0, or 1 if v1 is less than, equal to, or greater than v2, respectively.
+ */
+export function compareVersions(v1: string, v2: string): number {
+    const v1Parts = v1.split(/\./);
+    const v2Parts = v2.split(/\./);
+    for (let i = 0; i < v1Parts.length && i < v2Parts.length; i++) {
+        const v1PartValue = parseInt(v1Parts[i], 10);
+        const v2PartValue = parseInt(v2Parts[i], 10);
+
+        if (isNaN(v1PartValue) || isNaN(v2PartValue)) {
+            // Non-integer part, ignore it
+            continue;
+        }
+        if (v1PartValue > v2PartValue) {
+            return 1;
+        } else if (v1PartValue < v2PartValue) {
+            return -1;
+        }
+    }
+
+    // If we get here is means the versions are still equal
+    // but there could be extra parts to examine
+
+    if (v1Parts.length < v2Parts.length) {
+        // v2 has extra parts, which implies v1 is a lower version (e.g., v1 = 7.9 v2 = 7.9.1)
+        // unless each extra part is 0, in which case the two versions are equal (e.g., v1 = 7.9 v2 = 7.9.0)
+        for (let i = v1Parts.length; i < v2Parts.length; i++) {
+            const v2PartValue = parseInt(v2Parts[i], 10);
+
+            if (isNaN(v2PartValue)) {
+                // Non-integer part, ignore it
+                continue;
+            }
+            if (v2PartValue != 0) {
+                return -1;
+            }
+        }
+    }
+    if (v1Parts.length > v2Parts.length) {
+        // v1 has extra parts, which implies v1 is a higher version (e.g., v1 = 7.9.1 v2 = 7.9)
+        // unless each extra part is 0, in which case the two versions are equal (e.g., v1 = 7.9.0 v2 = 7.9)
+        for (let i = v2Parts.length; i < v1Parts.length; i++) {
+            const v1PartValue = parseInt(v1Parts[i], 10);
+
+            if (isNaN(v1PartValue)) {
+                // Non-integer part, ignore it
+                continue;
+            }
+            if (v1PartValue != 0) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This set of commits backdates support to GDB 7.6 and later - it had been GDB 8 and later.