### PR TITLE
Issue #178: Add more escaping on Windows for old GDB

### DIFF
--- a/src/mi/breakpoint.ts
+++ b/src/mi/breakpoint.ts
@@ -77,12 +77,9 @@ export function breakpointLocation(
         if (version8) {
             return `--source ${gdb.standardEscape(source)} --line ${line}`;
         } else {
-            let location = `${source}:${line}`;
-            if (location.includes(' ')) {
-                // double-escaping needed for old GDBs
-                location = `"${location}"`;
-            }
-            return `${gdb.standardEscape(location, false)}`;
+            // double-escaping/quoting needed for old GDBs
+            const location = `"${source}:${line}"`;
+            return `${gdb.standardEscape(location, true)}`;
         }
     } else {
         return version8


### PR DESCRIPTION
The handling of \ on Windows causes lots of minor issues. While
CDT only does the double-escaping of paths if there is whitespace,
on cdt-gdb-adapter we need to do it all the time as the effect
on original-location is different. In CDT we don't worry about
original-location, but in cdt-gdb-adapter we need to be able to
identify which DAP breakpoint location matches which GDB breakpoint
reliably.