### PR TITLE
Fix windows multithread cases

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1098,7 +1098,8 @@ export class GDBDebugSession extends LoggingDebugSession {
             if (!varobj) {
                 const varCreateResponse = await mi.sendVarCreate(this.gdb, {
                     expression: args.expression,
-                    frame: 'current',
+                    frameId: frame.frameId,
+                    threadId: frame.threadId,
                 });
                 varobj = this.gdb.varManager.addVar(
                     frame.frameId,
@@ -1131,7 +1132,11 @@ export class GDBDebugSession extends LoggingDebugSession {
                         });
                         const varCreateResponse = await mi.sendVarCreate(
                             this.gdb,
-                            { expression: args.expression, frame: 'current' }
+                            {
+                                expression: args.expression,
+                                frameId: frame.frameId,
+                                threadId: frame.threadId,
+                            }
                         );
                         varobj = this.gdb.varManager.addVar(
                             frame.frameId,
@@ -1688,8 +1693,9 @@ export class GDBDebugSession extends LoggingDebugSession {
                 if (!varobj) {
                     // create var in GDB and store it in the varMgr
                     const varCreateResponse = await mi.sendVarCreate(this.gdb, {
-                        frame: 'current',
                         expression: variable.name,
+                        frameId: frame.frameId,
+                        threadId: frame.threadId,
                     });
                     varobj = this.gdb.varManager.addVar(
                         frame.frameId,
@@ -1833,8 +1839,9 @@ export class GDBDebugSession extends LoggingDebugSession {
                         const varCreateResponse = await mi.sendVarCreate(
                             this.gdb,
                             {
-                                frame: 'current',
                                 expression: exprResponse.path_expr,
+                                frameId: frame.frameId,
+                                threadId: frame.threadId,
                             }
                         );
                         arrobj = this.gdb.varManager.addVar(

--- a/src/integration-tests/multithread.spec.ts
+++ b/src/integration-tests/multithread.spec.ts
@@ -15,13 +15,17 @@ import {
     openGdbConsole,
     gdbAsync,
     resolveLineTagLocations,
+    isRemoteTest,
 } from './utils';
 import { LaunchRequestArguments } from '../GDBDebugSession';
 import { expect } from 'chai';
 import * as path from 'path';
 import { fail } from 'assert';
+import * as os from 'os';
 
-describe('multithread', async () => {
+describe('multithread', async function () {
+    this.timeout(5000);
+
     let dc: CdtDebugClient;
     const program = path.join(testProgramsDir, 'MultiThread');
     const source = path.join(testProgramsDir, 'MultiThread.cc');
@@ -123,11 +127,19 @@ describe('multithread', async () => {
         }
     };
 
-    it('sees all threads (all-stop)', async () => {
+    it('sees all threads (all-stop)', async function () {
+        if (os.platform() === 'win32' && isRemoteTest) {
+            // The way thread names are set in remote tests on windows is unsupported
+            this.skip();
+        }
         await testCommon(false);
     });
 
-    it('sees all threads (non-stop)', async () => {
+    it('sees all threads (non-stop)', async function () {
+        if (os.platform() === 'win32') {
+            // non-stop unsupported on Windows
+            this.skip();
+        }
         await testCommon(true);
     });
 });

--- a/src/mi/exec.ts
+++ b/src/mi/exec.ts
@@ -25,7 +25,7 @@ export function sendExecRun(gdb: GDBBackend) {
 
 export function sendExecContinue(gdb: GDBBackend, threadId?: number) {
     let command = '-exec-continue';
-    if (threadId) {
+    if (threadId !== undefined) {
         command += ` --thread ${threadId}`;
     }
     return gdb.sendCommand(command);
@@ -33,7 +33,7 @@ export function sendExecContinue(gdb: GDBBackend, threadId?: number) {
 
 export function sendExecNext(gdb: GDBBackend, threadId?: number) {
     let command = '-exec-next';
-    if (threadId) {
+    if (threadId !== undefined) {
         command += ` --thread ${threadId}`;
     }
     return gdb.sendCommand(command);
@@ -41,7 +41,7 @@ export function sendExecNext(gdb: GDBBackend, threadId?: number) {
 
 export function sendExecStep(gdb: GDBBackend, threadId?: number) {
     let command = '-exec-step';
-    if (threadId) {
+    if (threadId !== undefined) {
         command += ` --thread ${threadId}`;
     }
     return gdb.sendCommand(command);
@@ -49,7 +49,7 @@ export function sendExecStep(gdb: GDBBackend, threadId?: number) {
 
 export function sendExecFinish(gdb: GDBBackend, threadId?: number) {
     let command = '-exec-finish';
-    if (threadId) {
+    if (threadId !== undefined) {
         command += ` --thread ${threadId}`;
     }
     return gdb.sendCommand(command);

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -77,14 +77,24 @@ export function sendVarCreate(
         frameAddr?: string;
         frame?: 'current' | 'floating';
         expression: string;
+        threadId?: number;
+        frameId?: number;
     }
 ): Promise<MIVarCreateResponse> {
     let command = '-var-create';
+    if (params.threadId !== undefined) {
+        command += ` --thread ${params.threadId}`;
+    }
+    if (params.frameId !== undefined) {
+        command += ` --frame ${params.frameId}`;
+    }
+
     command += ` ${params.name ? params.name : '-'}`;
     if (params.frameAddr) {
         command += ` ${params.frameAddr}`;
     } else if (params.frame) {
         switch (params.frame) {
+            default:
             case 'current':
                 command += ' *';
                 break;
@@ -92,6 +102,8 @@ export function sendVarCreate(
                 command += ' @';
                 break;
         }
+    } else {
+        command += ' *';
     }
     command += ` ${quote(params.expression)}`;
 

--- a/src/varManager.ts
+++ b/src/varManager.ts
@@ -150,6 +150,8 @@ export class VarManager {
                 const createResponse = await sendVarCreate(this.gdb, {
                     frame: 'current',
                     expression: varobj.expression,
+                    frameId: frameId,
+                    threadId: threadId,
                 });
                 returnVar = this.addVar(
                     frameId,


### PR DESCRIPTION
Follow on work for #28 this fixes errors identified that affects Windows only, including most critically making sure the thread/frame is specified to `-var-create`.

The multithread test, which access variables on different threads and frames verifies the var create is done on the correct thread/frame.