### PR TITLE
Improve parser regex performance

### DIFF
--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -22,19 +22,21 @@ export class MIParser {
     public parse(stream: Readable): Promise<void> {
         return new Promise((resolve) => {
             this.waitReady = resolve;
-            const lineRegex = /(.*)(\r?\n)/;
+            const lineBreakRegex = /\r?\n/;
             let buff = '';
             stream.on('data', (chunk) => {
-                buff += chunk.toString();
-                let regexArray = lineRegex.exec(buff);
+                const newChunk = chunk.toString();
+                let regexArray = lineBreakRegex.exec(newChunk);
+                if (regexArray) {
+                    regexArray.index += buff.length;
+                }
+                buff += newChunk;
                 while (regexArray) {
-                    this.line = regexArray[1];
+                    this.line = buff.slice(0, regexArray.index);
                     this.pos = 0;
                     this.handleLine();
-                    buff = buff.substring(
-                        regexArray[1].length + regexArray[2].length
-                    );
-                    regexArray = lineRegex.exec(buff);
+                    buff = buff.slice(regexArray.index + regexArray[0].length);
+                    regexArray = lineBreakRegex.exec(buff);
                 }
             });
         });


### PR DESCRIPTION
If a large message comes in many parts, the current code of the parser is very inefficient: it rechecks the entire buffer, even though when a new chunk arrives, we can guarantee that the regex cannot match the existing buffer, and it uses a capture that will always just capture everything from the beginning of the string to the point of a line break.

This PR addresses both of those deficiencies:
 - When a new chunk arrives, only the new chunk is checked for a newline sequence.
 - No captures are used; instead the `index` field of the result is used to pick the end of the slice sent for parsing.