### PR TITLE
Run all tests in non-stop mode (in addition to all-stop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "clean": "git clean -dfx",
     "docker:build": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn",
     "docker:test": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn test",
-    "test": "yarn test:integration && yarn test:pty && yarn test:integration-run-in-terminal && yarn test:integration-remote-target && yarn test:integration-remote-target-run-in-terminal && yarn test:integration-gdb-async-off && yarn test:integration-gdb-async-off-remote-target",
+    "test": "yarn test:integration && yarn test:pty && yarn test:integration-run-in-terminal && yarn test:integration-remote-target && yarn test:integration-remote-target-run-in-terminal && yarn test:integration-gdb-async-off && yarn test:integration-gdb-async-off-remote-target && yarn test:integration-gdb-non-stop",
     "test:integration": "cross-env JUNIT_REPORT_PATH=test-reports/integration.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
     "test:integration-run-in-terminal": "cross-env JUNIT_REPORT_PATH=test-reports/integration-run-in-terminal.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --run-in-terminal --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
     "test:integration-remote-target": "cross-env JUNIT_REPORT_PATH=test-reports/integration-remote-target.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --test-remote --timeout 5000 --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
     "test:integration-remote-target-run-in-terminal": "cross-env JUNIT_REPORT_PATH=test-reports/integration-remote-target-run-in-terminal.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --test-remote --timeout 5000 --run-in-terminal --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
     "test:integration-gdb-async-off": "cross-env JUNIT_REPORT_PATH=test-reports/integration-gdb-async-off.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js --test-gdb-async-off",
     "test:integration-gdb-async-off-remote-target": "cross-env JUNIT_REPORT_PATH=test-reports/integration-gdb-async-off-remote-target.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js --timeout 5000 --test-gdb-async-off --test-remote",
+    "test:integration-gdb-non-stop": "cross-env JUNIT_REPORT_PATH=test-reports/integration-gdb-non-stop.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js --test-gdb-non-stop",
     "test:pty": "cross-env JUNIT_REPORT_PATH=test-reports/native.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/native/*.spec.js"
   },
   "repository": {

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../GDBTargetDebugSession';
 import { CdtDebugClient } from './debugClient';
 import { standardBeforeEach, testProgramsDir, gdbServerPath } from './utils';
-import { gdbPath, openGdbConsole, gdbAsync } from './utils';
+import { gdbPath, openGdbConsole, gdbAsync, gdbNonStop } from './utils';
 
 describe('attach remote', function () {
     let dc: CdtDebugClient;
@@ -67,6 +67,7 @@ describe('attach remote', function () {
                 program: emptyProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
                 target: {
                     type: 'remote',
                     parameters: [`localhost:${port}`],

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -18,6 +18,7 @@ import {
     testProgramsDir,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     getScopes,
     verifyVariable,
     gdbVersionAtLeast,
@@ -36,6 +37,7 @@ describe('breakpoints', async () => {
             program: path.join(testProgramsDir, 'count'),
             openGdbConsole,
             gdbAsync,
+            gdbNonStop,
             logFile: '/tmp/log',
         } as LaunchRequestArguments);
     });

--- a/src/integration-tests/diassemble.spec.ts
+++ b/src/integration-tests/diassemble.spec.ts
@@ -17,6 +17,7 @@ import {
     gdbPath,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     standardBeforeEach,
     testProgramsDir,
 } from './utils';
@@ -36,6 +37,7 @@ describe('Disassembly Test Suite', function () {
                 program: disProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: disSrc,

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -17,6 +17,7 @@ import {
     getScopes,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     Scope,
     standardBeforeEach,
     testProgramsDir,
@@ -42,6 +43,7 @@ describe('evaluate request', function () {
                 program: evaluateProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             },
             {
                 path: evaluateSrc,

--- a/src/integration-tests/functionBreakpoints.spec.ts
+++ b/src/integration-tests/functionBreakpoints.spec.ts
@@ -19,6 +19,7 @@ import {
     testProgramsDir,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     getScopes,
 } from './utils';
 
@@ -34,6 +35,7 @@ describe('function breakpoints', async () => {
             program: join(testProgramsDir, 'functions'),
             openGdbConsole,
             gdbAsync,
+            gdbNonStop,
         } as LaunchRequestArguments);
     });
 

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { LaunchRequestArguments } from '../GDBDebugSession';
 import { CdtDebugClient } from './debugClient';
 import { standardBeforeEach, testProgramsDir } from './utils';
-import { gdbPath, openGdbConsole, gdbAsync } from './utils';
+import { gdbPath, openGdbConsole, gdbAsync, gdbNonStop } from './utils';
 
 describe('launch', function () {
     let dc: CdtDebugClient;
@@ -43,6 +43,7 @@ describe('launch', function () {
                 program: emptyProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: emptySrc,
@@ -59,6 +60,7 @@ describe('launch', function () {
                 program: '/does/not/exist',
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments)
                 .then(reject)
                 .catch(resolve);
@@ -83,6 +85,7 @@ describe('launch', function () {
                 program: emptySpaceProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: emptySpaceSrc,

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '../GDBTargetDebugSession';
 import { CdtDebugClient } from './debugClient';
 import { standardBeforeEach, testProgramsDir } from './utils';
-import { gdbPath, openGdbConsole, gdbAsync } from './utils';
+import { gdbPath, openGdbConsole, gdbAsync, gdbNonStop } from './utils';
 
 describe('launch remote', function () {
     let dc: CdtDebugClient;
@@ -43,6 +43,7 @@ describe('launch remote', function () {
                 program: emptyProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
                 target: {
                     type: 'remote',
                 } as TargetLaunchArguments,

--- a/src/integration-tests/logpoints.spec.ts
+++ b/src/integration-tests/logpoints.spec.ts
@@ -18,6 +18,7 @@ import {
     testProgramsDir,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
 } from './utils';
 
 describe('logpoints', async () => {
@@ -32,6 +33,7 @@ describe('logpoints', async () => {
             program: join(testProgramsDir, 'count'),
             openGdbConsole,
             gdbAsync,
+            gdbNonStop,
         } as LaunchRequestArguments);
     });
 

--- a/src/integration-tests/mem-cdt-custom.spec.ts
+++ b/src/integration-tests/mem-cdt-custom.spec.ts
@@ -18,6 +18,7 @@ import {
     gdbPath,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     standardBeforeEach,
     testProgramsDir,
 } from './utils';
@@ -37,6 +38,7 @@ describe('Memory Test Suite for cdt-gdb-adapter/Memory custom request', function
                 program: memProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: memSrc,

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -22,6 +22,7 @@ import {
     gdbPath,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     standardBeforeEach,
     testProgramsDir,
 } from './utils';
@@ -41,6 +42,7 @@ describe('Memory Test Suite', function () {
                 program: memProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: memSrc,

--- a/src/integration-tests/pause.spec.ts
+++ b/src/integration-tests/pause.spec.ts
@@ -14,6 +14,7 @@ import {
     testProgramsDir,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     isRemoteTest,
 } from './utils';
 import { LaunchRequestArguments } from '../GDBDebugSession';
@@ -42,6 +43,7 @@ describe('pause', async () => {
             program: path.join(testProgramsDir, 'loopforever'),
             openGdbConsole,
             gdbAsync,
+            gdbNonStop,
             logFile: '/tmp/log',
         } as LaunchRequestArguments);
         await dc.configurationDoneRequest();

--- a/src/integration-tests/stop.spec.ts
+++ b/src/integration-tests/stop.spec.ts
@@ -14,6 +14,7 @@ import {
     testProgramsDir,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
 } from './utils';
 import { LaunchRequestArguments } from '../GDBDebugSession';
 import { expect } from 'chai';
@@ -37,6 +38,7 @@ describe('stop', async () => {
             program: path.join(testProgramsDir, 'segv'),
             openGdbConsole,
             gdbAsync,
+            gdbNonStop,
         } as LaunchRequestArguments);
         await dc.configurationDoneRequest();
         const stoppedEvent = await dc.waitForEvent('stopped');

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -198,6 +198,8 @@ export const isRemoteTest: boolean =
     process.argv.indexOf('--test-remote') !== -1;
 export const gdbAsync: boolean =
     process.argv.indexOf('--test-gdb-async-off') === -1;
+export const gdbNonStop: boolean =
+    process.argv.indexOf('--test-gdb-non-stop') !== -1;
 export const gdbPath: string | undefined = getGdbPathCli();
 export const gdbServerPath: string = getGdbServerPathCli();
 export const debugServerPort: number | undefined = getDebugServerPortCli();

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -17,6 +17,7 @@ import {
     getScopes,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     resolveLineTagLocations,
     Scope,
     standardBeforeEach,
@@ -55,6 +56,7 @@ describe('Variables Test Suite', function () {
                 program: varsProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: varsSrc,

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -18,6 +18,7 @@ import {
     getScopes,
     openGdbConsole,
     gdbAsync,
+    gdbNonStop,
     resolveLineTagLocations,
     Scope,
     standardBeforeEach,
@@ -59,6 +60,7 @@ describe('Variables CPP Test Suite', function () {
                 program: varsCppProgram,
                 openGdbConsole,
                 gdbAsync,
+                gdbNonStop,
             } as LaunchRequestArguments,
             {
                 path: varsCppSrc,


### PR DESCRIPTION
Now that we support non-stop mode, run all the tests again in non-stop mode to make sure that they work equally well in non-stop as all-stop.