### PR TITLE
Skip all tests when running non-stop tests on Windows

### DIFF
--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -12,6 +12,7 @@ import { expect } from 'chai';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { CdtDebugClient } from './debugClient';
 import { compareVersions, getGdbVersion } from '../util';
@@ -204,6 +205,13 @@ export const gdbPath: string | undefined = getGdbPathCli();
 export const gdbServerPath: string = getGdbServerPathCli();
 export const debugServerPort: number | undefined = getDebugServerPortCli();
 export const defaultAdapter: string = getDefaultAdapterCli();
+
+before(function () {
+    if (gdbNonStop && os.platform() === 'win32') {
+        // non-stop unsupported on Windows
+        this.skip();
+    }
+});
 
 function getGdbPathCli(): string | undefined {
     const keyIndex = process.argv.indexOf('--gdb-path');


### PR DESCRIPTION
Follow up to #206 to skip all the non-stop tests when running on Windows because Windows native debugging does not support non-stop mode.

The skipping is the same condition as in multithread test, just globally when `--test-gdb-non-stop` is used: https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/80836a832c1d7cff86dd335c4c76b864f8fb3c99/src/integration-tests/multithread.spec.ts#L139-L142