### PR TITLE
Small test cleanups

### DIFF
--- a/src/integration-tests/multithread.spec.ts
+++ b/src/integration-tests/multithread.spec.ts
@@ -57,10 +57,6 @@ describe('multithread', async function () {
             // The way thread names are set in remote tests on windows is unsupported
             this.skip();
         }
-        if (gdbNonStop && os.platform() === 'win32') {
-            // non-stop unsupported on Windows
-            this.skip();
-        }
 
         await dc.hitBreakpoint(
             fillDefaults(this.test, {

--- a/src/integration-tests/multithread.spec.ts
+++ b/src/integration-tests/multithread.spec.ts
@@ -52,7 +52,7 @@ describe('multithread', async function () {
         await dc.stop();
     });
 
-    it('sees all threads (all-stop)', async function () {
+    it('sees all threads', async function () {
         if (!gdbNonStop && os.platform() === 'win32' && isRemoteTest) {
             // The way thread names are set in remote tests on windows is unsupported
             this.skip();


### PR DESCRIPTION
Some leftover cleanups related to refactoring tests to run non-stop tests.