### PR TITLE
Fix Watch view for multiple session debugging.

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1225,11 +1225,10 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(
-                response,
-                1,
-                err instanceof Error ? err.message : String(err)
-            );
+            // For multiple debug session, another sessions can catch error in case of not have variable in source.
+            // Cannot send ErrorResponse because it make another session are failed.
+            // Send the response notify 'Error: could not evaluate expression' instead of ErrorResponse.
+            this.sendResponse(response);
         }
     }
 


### PR DESCRIPTION
Description: In multiple session debugging, all sessions will send command to get result value of  variables added in Watch view. But only 1 session can send command successfully, another session  will catch the error and send ErrorResponse to client. The ErrorRespone makes another session  fail and cannot update the remaining in Watch view.

Solution: Replace ErrorResponse by using response notify 'Error: could not evaluate expression'. It will show the error notify on another sessions that do not have the variable in source file.