### PR TITLE
Disassembly view CVe make ARM thread is terminated

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -178,6 +178,7 @@ export class GDBDebugSession extends LoggingDebugSession {
     // therefore be resumed after breakpoints are inserted.
     protected waitPausedNeeded = false;
     protected isInitialized = false;
+    protected isNotSupportDisassemble = false;
 
     constructor() {
         super();
@@ -1292,6 +1293,11 @@ export class GDBDebugSession extends LoggingDebugSession {
             let lastStartOffset = -1;
             const instructions: DebugProtocol.DisassembledInstruction[] = [];
             let oneIterationOnly = false;
+            if (this.isNotSupportDisassemble) {
+                response.body = { instructions };
+                this.sendResponse(response);
+                return;
+            }
             outer_loop: while (
                 instructions.length < args.instructionCount &&
                 !oneIterationOnly


### PR DESCRIPTION
+ Description: When using multiple debugging (ARM+CVe) for V4H devices, open Disassemble 
                    view in CVe thread, ARM thread will be terminated automatically.
+ Root cause: In e2studio, ARM and CVe debugging via Renesas GDB server (Passthrough).
                   But in VS code, it connects directly to Linux Applications. ARM thread terminated 
                   in case it's running, If ARM thread is suspended before opening Disassemble view in 
                   CVe thread, the bug does not occur.
+ Solution:    Currently, we have no solution to use Disassemble view for CVe, but it needs
                  to disable Disassemble view of CVe thread to fix degradation in the ARM thread.