### PR TITLE
Allow pre-filling launch/attach on command line to adapter

### DIFF
--- a/.mocharc-windows-ci.json
+++ b/.mocharc-windows-ci.json
@@ -1,3 +1,4 @@
 {
+  "//": "This timeout should match what is in CdtDebugClient constructor",
   "timeout": "25000"
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,4 @@
 {
+  "//": "This timeout should match what is in CdtDebugClient constructor",
   "timeout": "5000"
 }

--- a/README.md
+++ b/README.md
@@ -14,8 +14,53 @@ Build is pretty simple.
 yarn
 ```
 
+## Running
+
 The entry point for the adapter is `cdtDebugAdapter` for local debugging
 and `cdtDebugTargetAdapter` for target (remote) debugging.
+
+### Command line arguments
+
+#### `--server=PORT`
+
+Start the adapter listening on the given port instead of on stdin/stdout.
+
+#### `--config=INITIALCONFIG`
+
+Start the adapter using the given configuration as a starting point for the args in `launch` or `attach` request.
+
+For example, the default GDB can be set like this:
+
+```sh
+    node debugTargetAdapter.js --config='{"gdb":"arm-none-eabi-gdb"}'
+```
+
+The config can be passed on the command line as JSON, or a response file can be used by starting the argument with `@`.
+The rest of the argument will be interpreted as a file name to read.
+For example, to start the adapter defaulting to a process ID to attach to, create a file containing the JSON and reference it like this:
+
+```sh
+    cat >config.json <<END
+    {
+      "processId": 1234
+    }
+    END
+    node debugAdapter.js --config=@config.json
+
+```
+
+#### `--config-frozen=FROZENCONFIG`
+
+Similar to `--config`, the `--config-frozen` sets the provided configuration fields in the args to the `launch` or `attach` request to the given values, not allowing the user to override them.
+Specifying which type of request is allowed (`launch` or `attach`) can be specified with the `request` field.
+When freezing the type of request, regardless of which type of request the user requested, the frozen request type will be used.
+
+For example, the adapter can be configured for program to be frozen to a specific value.
+This may be useful for starting adapters in a container and exposing the server port.
+
+```sh
+    node debugAdapter.js --server=23221 --config-frozen='{"program":"/path/to/my.elf"}'
+```
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -60,13 +60,15 @@
   "dependencies": {
     "@vscode/debugadapter": "^1.48.0",
     "@vscode/debugprotocol": "^1.48.0",
-    "node-addon-api": "^4.3.0"
+    "node-addon-api": "^4.3.0",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/chai-string": "^1.4.2",
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.18.17",
+    "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "@vscode/debugadapter-testsupport": "^1.37.1",

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -9,7 +9,9 @@
  *********************************************************************/
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs';
 import {
+    DebugSession,
     Handles,
     InitializedEvent,
     Logger,
@@ -152,6 +154,18 @@ export function base64ToHex(base64: string): string {
 }
 
 export class GDBDebugSession extends LoggingDebugSession {
+    /**
+     * Initial (aka default) configuration for launch/attach request
+     * typically supplied with the --config command line argument.
+     */
+    protected static defaultRequestArguments?: any;
+
+    /**
+     * Frozen configuration for launch/attach request
+     * typically supplied with the --config-frozen command line argument.
+     */
+    protected static frozenRequestArguments?: { request?: string };
+
     protected gdb: GDBBackend = this.createBackend();
     protected isAttach = false;
     // isRunning === true means there are no threads stopped.
@@ -182,6 +196,66 @@ export class GDBDebugSession extends LoggingDebugSession {
     constructor() {
         super();
         this.logger = logger;
+    }
+
+    /**
+     * Main entry point
+     */
+    public static run(debugSession: typeof GDBDebugSession) {
+        GDBDebugSession.processArgv(process.argv.slice(2));
+        DebugSession.run(debugSession);
+    }
+
+    /**
+     * Parse an optional config file which is a JSON string of launch/attach request arguments.
+     * The config can be a response file by starting with an @.
+     */
+    public static processArgv(args: string[]) {
+        args.forEach(function (val, _index, _array) {
+            const configMatch = /^--config(-frozen)?=(.*)$/.exec(val);
+            if (configMatch) {
+                let configJson;
+                const configStr = configMatch[2];
+                if (configStr.startsWith('@')) {
+                    const configFile = configStr.slice(1);
+                    configJson = JSON.parse(
+                        fs.readFileSync(configFile).toString('utf8')
+                    );
+                } else {
+                    configJson = JSON.parse(configStr);
+                }
+                if (configMatch[1]) {
+                    GDBDebugSession.frozenRequestArguments = configJson;
+                } else {
+                    GDBDebugSession.defaultRequestArguments = configJson;
+                }
+            }
+        });
+    }
+
+    /**
+     * Apply the initial and frozen launch/attach request arguments.
+     * @param request the default request type to return if request type is not frozen
+     * @param args the arguments from the user to apply initial and frozen arguments to.
+     * @returns resolved request type and the resolved arguments
+     */
+    protected applyRequestArguments(
+        request: 'launch' | 'attach',
+        args: LaunchRequestArguments | AttachRequestArguments
+    ): ['launch' | 'attach', LaunchRequestArguments | AttachRequestArguments] {
+        const frozenRequest = GDBDebugSession.frozenRequestArguments?.request;
+        if (frozenRequest === 'launch' || frozenRequest === 'attach') {
+            request = frozenRequest;
+        }
+
+        return [
+            request,
+            {
+                ...GDBDebugSession.defaultRequestArguments,
+                ...args,
+                ...GDBDebugSession.frozenRequestArguments,
+            },
+        ];
     }
 
     protected createBackend(): GDBBackend {
@@ -305,7 +379,11 @@ export class GDBDebugSession extends LoggingDebugSession {
         args: AttachRequestArguments
     ): Promise<void> {
         try {
-            await this.attachOrLaunchRequest(response, 'attach', args);
+            const [request, resolvedArgs] = this.applyRequestArguments(
+                'attach',
+                args
+            );
+            await this.attachOrLaunchRequest(response, request, resolvedArgs);
         } catch (err) {
             this.sendErrorResponse(
                 response,
@@ -320,7 +398,11 @@ export class GDBDebugSession extends LoggingDebugSession {
         args: LaunchRequestArguments
     ): Promise<void> {
         try {
-            await this.attachOrLaunchRequest(response, 'launch', args);
+            const [request, resolvedArgs] = this.applyRequestArguments(
+                'launch',
+                args
+            );
+            await this.attachOrLaunchRequest(response, request, resolvedArgs);
         } catch (err) {
             this.sendErrorResponse(
                 response,

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -264,6 +264,14 @@ export class GDBDebugSession extends LoggingDebugSession {
         );
 
         await this.spawn(args);
+        if (!args.program) {
+            this.sendErrorResponse(
+                response,
+                1,
+                'The program must be specified in the request arguments'
+            );
+            return;
+        }
         await this.gdb.sendFileExecAndSymbols(args.program);
         await this.gdb.sendEnablePrettyPrint();
 

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -86,6 +86,17 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;
+            if (
+                launchArgs.target?.serverParameters === undefined &&
+                !launchArgs.program
+            ) {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    'The program must be specified in the launch request arguments'
+                );
+                return;
+            }
             await this.startGDBServer(launchArgs);
         }
 

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -108,7 +108,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         args: TargetLaunchRequestArguments
     ): Promise<void> {
         try {
-            await this.attachOrLaunchRequest(response, 'launch', args);
+            const [request, resolvedArgs] = this.applyRequestArguments(
+                'launch',
+                args
+            );
+            await this.attachOrLaunchRequest(response, request, resolvedArgs);
         } catch (err) {
             this.sendErrorResponse(
                 response,
@@ -123,7 +127,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         args: TargetAttachRequestArguments
     ): Promise<void> {
         try {
-            await this.attachOrLaunchRequest(response, 'attach', args);
+            const [request, resolvedArgs] = this.applyRequestArguments(
+                'attach',
+                args
+            );
+            await this.attachOrLaunchRequest(response, request, resolvedArgs);
         } catch (err) {
             this.sendErrorResponse(
                 response,

--- a/src/integration-tests/config.spec.ts
+++ b/src/integration-tests/config.spec.ts
@@ -1,0 +1,165 @@
+/*********************************************************************
+ * Copyright (c) 2023 Kichwa Coders Canada Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as path from 'path';
+import * as tmp from 'tmp';
+import * as fs from 'fs';
+import {
+    LaunchRequestArguments,
+    AttachRequestArguments,
+} from '../GDBDebugSession';
+import {
+    debugServerPort,
+    defaultAdapter,
+    fillDefaults,
+    standardBeforeEach,
+    testProgramsDir,
+} from './utils';
+
+describe('config', function () {
+    const emptyProgram = path.join(testProgramsDir, 'empty');
+    const emptySrc = path.join(testProgramsDir, 'empty.c');
+
+    async function verifyLaunchWorks(
+        test: Mocha.Context,
+        commandLine: string[],
+        requestArgs: LaunchRequestArguments
+    ) {
+        if (debugServerPort) {
+            // This test requires launching the adapter to work
+            test.skip();
+        }
+
+        const dc = await standardBeforeEach(defaultAdapter, commandLine);
+
+        try {
+            await dc.hitBreakpoint(fillDefaults(test.test, requestArgs), {
+                path: emptySrc,
+                line: 3,
+            });
+        } finally {
+            await dc.stop();
+        }
+    }
+
+    it('can specify program via --config=', async function () {
+        const config = { program: emptyProgram };
+        await verifyLaunchWorks(
+            this,
+            [`--config=${JSON.stringify(config)}`],
+            {} as LaunchRequestArguments
+        );
+    });
+
+    it('program via --config= can be overridden', async function () {
+        const config = { program: '/program/that/does/not/exist' };
+        await verifyLaunchWorks(this, [`--config=${JSON.stringify(config)}`], {
+            program: emptyProgram,
+        } as LaunchRequestArguments);
+    });
+
+    it('can specify program via --config-frozen=', async function () {
+        const config = { program: emptyProgram };
+        await verifyLaunchWorks(
+            this,
+            [`--config-frozen=${JSON.stringify(config)}`],
+            {} as LaunchRequestArguments
+        );
+    });
+
+    it('program via --config-frozen= can not be overridden', async function () {
+        const config = { program: emptyProgram };
+        await verifyLaunchWorks(
+            this,
+            [`--config-frozen=${JSON.stringify(config)}`],
+            {
+                program: '/program/that/does/not/exist',
+            } as LaunchRequestArguments
+        );
+    });
+
+    it('can specify program via --config= using response file', async function () {
+        const config = { program: emptyProgram };
+        const json = JSON.stringify(config);
+        const jsonFile = tmp.fileSync();
+        fs.writeFileSync(jsonFile.fd, json);
+        fs.closeSync(jsonFile.fd);
+
+        await verifyLaunchWorks(
+            this,
+            [`--config=@${jsonFile.name}`],
+            {} as LaunchRequestArguments
+        );
+    });
+
+    it('can specify program via --config-frozen= using response file', async function () {
+        const config = { program: emptyProgram };
+        const json = JSON.stringify(config);
+        const jsonFile = tmp.fileSync();
+        fs.writeFileSync(jsonFile.fd, json);
+        fs.closeSync(jsonFile.fd);
+
+        await verifyLaunchWorks(
+            this,
+            [`--config-frozen=@${jsonFile.name}`],
+            {} as LaunchRequestArguments
+        );
+    });
+
+    // This test most closely models the original design goal
+    // for the change that added --config and --config-frozen
+    // as discussed in #227 and #228
+    // In summary we force a launch request for the given program,
+    // but the user does not specify the program and specifies
+    // an attach request
+    it('config frozen forces specific launch type', async function () {
+        if (debugServerPort) {
+            // This test requires launching the adapter to work
+            this.skip();
+        }
+
+        const config = { request: 'launch', program: emptyProgram };
+
+        // Launch the adapter with the frozen config
+        const dc = await standardBeforeEach(defaultAdapter, [
+            `--config-frozen=${JSON.stringify(config)}`,
+        ]);
+
+        try {
+            await Promise.all([
+                // Do an attach request omitting the program that we want
+                // the adapter to force into a launch request
+                dc.attachRequest(
+                    fillDefaults(this.test, {} as AttachRequestArguments)
+                ),
+
+                // The rest of this code is to ensure we launcher properly by verifying
+                // we can run to a breakpoint
+                dc.waitForEvent('initialized').then((_event) => {
+                    return dc
+                        .setBreakpointsRequest({
+                            lines: [3],
+                            breakpoints: [{ line: 3 }],
+                            source: { path: emptySrc },
+                        })
+                        .then((_response) => {
+                            return dc.configurationDoneRequest();
+                        });
+                }),
+                dc.assertStoppedLocation('breakpoint', {
+                    path: emptySrc,
+                    line: 3,
+                }),
+            ]);
+        } finally {
+            await dc.stop();
+        }
+    });
+});

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -74,4 +74,18 @@ describe('launch', function () {
             }
         );
     });
+
+    it('provides a decent error if program is omitted', async function () {
+        const errorMessage = await new Promise<Error>((resolve, reject) => {
+            dc.launchRequest(
+                fillDefaults(this.test, {} as LaunchRequestArguments)
+            )
+                .then(reject)
+                .catch(resolve);
+        });
+
+        expect(errorMessage.message).to.satisfy((msg: string) =>
+            msg.includes('program must be specified')
+        );
+    });
 });

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -201,6 +201,10 @@ export async function standardBeforeEach(
             shell: true,
         }
     );
+
+    // These timeouts should match what is in .mocharc.json and .mocharc-windows-ci.json
+    dc.defaultTimeout = os.platform() === 'win32' ? 25000 : 5000;
+
     await dc.start(debugServerPort);
     await dc.initializeRequest();
 

--- a/src/integration-tests/utils.ts
+++ b/src/integration-tests/utils.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2018 Ericsson and others
+ * Copyright (c) 2018, 2023 Ericsson and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -181,30 +181,11 @@ export const testProgramsDir = path.join(
     'test-programs'
 );
 
-function getAdapterAndArgs(adapter?: string): string {
-    const chosenAdapter = adapter !== undefined ? adapter : defaultAdapter;
-    let args: string = path.join(__dirname, '../../dist', chosenAdapter);
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-    return args;
-}
-
 export async function standardBeforeEach(
-    adapter?: string
+    adapter?: string,
+    extraArgs?: string[]
 ): Promise<CdtDebugClient> {
-    const dc: CdtDebugClient = new CdtDebugClient(
-        'node',
-        getAdapterAndArgs(adapter),
-        'cppdbg',
-        {
-            shell: true,
-        }
-    );
-
-    // These timeouts should match what is in .mocharc.json and .mocharc-windows-ci.json
-    dc.defaultTimeout = os.platform() === 'win32' ? 25000 : 5000;
-
+    const dc: CdtDebugClient = new CdtDebugClient(adapter, extraArgs);
     await dc.start(debugServerPort);
     await dc.initializeRequest();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,6 +213,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.17.tgz#37d3c01043fd09f3f17ffa8c17062bbb580f9558"
   integrity sha512-oajWz4kOajqpKJMPgnCvBajPq8QAvl2xIWoFjlAJPKGu6n7pjov5SxGE45a+0RxHDoo4ycOMoZw1SCOWtDERbw==
 
+"@types/tmp@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
+
 "@typescript-eslint/eslint-plugin@^5.10.1":
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz#870195d0f2146b36d11fc71131b75aba52354c69"
@@ -2445,7 +2450,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -2758,6 +2763,13 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
#### `--config=INITIALCONFIG`

Start the adapter using the given configuration as a starting point for the args in `launch` or `attach` request.

For example, the default GDB can be set like this:

```sh
    node debugTargetAdapter.js --config='{"gdb":"arm-none-eabi-gdb"}'
```

The config can be passed on the command line as JSON, or a response file can be used by starting the argument with `@`.
The rest of the argument will be interpreted as a file name to read.
For example, to start the adapter defaulting to a process ID to attach to, create a file containing the JSON and reference it like this:

```sh
    cat >config.json <<END
    {
      "processId": 1234
    }
    END
    node debugAdapter.js --config=@config.json

```

#### `--config-frozen=FROZENCONFIG`

Similar to `--config`, the `--config-frozen` sets the provided configuration fields in the args to the `launch` or `attach` request to the given values, not allowing the user to override them.
Specifying which type of request is allowed (`launch` or `attach`) can be specified with the `request` field.

For example, the adapter can be configured for program to be frozen to a specific value.
This may be useful for starting adapters in a container and exposing the server port.

```sh
    node debugAdapter.js --server=23221 --config-frozen='{"program":"/path/to/my.elf"}'
```

Fixes #227 