### PR TITLE
Add binary entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Build is pretty simple.
 yarn
 ```
 
-The entry point for the adapter is `out/debugAdapter.js` for local debugging
-and `out/debugTargetAdapter.js` for target (remote) debugging.g
+The entry point for the adapter is `cdtDebugAdapter` for local debugging
+and `cdtDebugTargetAdapter` for target (remote) debugging.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "gdb adapter implementing the debug adapter protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "cdtDebugAdapter": "./dist/debugAdapter.js",
+    "cdtDebugTargetAdapter": "./dist/debugTargetAdapter.js"
+  },
   "scripts": {
     "install": "node install.js",
     "nativebuild": "node-gyp rebuild",


### PR DESCRIPTION
This PR adds binary entries for the debugger entry points.

This means that when the package is installed globally, you can execute the debugger using `cdtDebugTargetAdapter` rather than fully qualifying the javascript file (e.g. `/usr/local/lib/node_modules/cdt-gdb-adapter/dist/debugTargetAdapter.js`)