### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-adapter",
-  "version": "0.0.16-next",
+  "version": "0.0.17-next",
   "description": "gdb adapter implementing the debug adapter protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
@thegecko the build publishes automatically to NPM. With the significant change for #227 bump the version number to be able to more easily distinguish versions.

