### PR TITLE
Include node environment hint for binaries

### DIFF
--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*********************************************************************
  * Copyright (c) 2018 QNX Software Systems and others
  *

--- a/src/debugTargetAdapter.ts
+++ b/src/debugTargetAdapter.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*********************************************************************
  * Copyright (c) 2018 QNX Software Systems and others
  *


### PR DESCRIPTION
This helps execute the global binaries without needing to specify the node runtime.