### PR TITLE
Ensure --frame is included even for frame 0

### DIFF
--- a/src/mi/stack.ts
+++ b/src/mi/stack.ts
@@ -26,7 +26,7 @@ export function sendStackInfoDepth(
     }
 ): Promise<MIStackInfoDepthResponse> {
     let command = '-stack-info-depth';
-    if (params.threadId) {
+    if (params.threadId !== undefined) {
         command += ` --thread ${params.threadId}`;
     }
     if (params.maxDepth) {
@@ -47,7 +47,7 @@ export function sendStackListFramesRequest(
     stack: MIFrameInfo[];
 }> {
     let command = '-stack-list-frames';
-    if (params.threadId) {
+    if (params.threadId !== undefined) {
         command += ` --thread ${params.threadId}`;
     }
     if (params.noFrameFilters) {
@@ -88,10 +88,10 @@ export function sendStackListVariables(
     if (params.skipUnavailable) {
         command += ' --skip-unavailable';
     }
-    if (params.thread) {
+    if (params.thread !== undefined) {
         command += ` --thread ${params.thread}`;
     }
-    if (params.frame) {
+    if (params.frame !== undefined) {
         command += ` --frame ${params.frame}`;
     }
     command += ` --${params.printValues}`;


### PR DESCRIPTION
Some commands take a --frame or --thread, but the code had a common javascript error of `if (numberVar)` instead of `if (numberVar !== undefined)`.

For threads this isn't often a problem as GDB doesn't use thread 0 typically. But for frames this is a problem as `--frame 0` was being omitted, leaving GDB to return info about the last frame that was accessed, e.g like this:

```
-stack-list-variables --thread 4 --frame 1 --simple-values
-stack-list-variables --thread 4 --simple-values
```

Because the second line doesn't include the frame, GDB uses frame 1 still. However that will lead to errors as it should be frame 0 that is queried.

Fixes #235