### PR TITLE
Add a test executable with a broken shared library

### DIFF
--- a/src/integration-tests/test-programs/BrokenSO_libsomea.c
+++ b/src/integration-tests/test-programs/BrokenSO_libsomea.c
@@ -1,0 +1,1 @@
+void a(void) {}

--- a/src/integration-tests/test-programs/BrokenSO_libsomeb.c
+++ b/src/integration-tests/test-programs/BrokenSO_libsomeb.c
@@ -1,0 +1,1 @@
+void b(void) {}

--- a/src/integration-tests/test-programs/BrokenSO_main.c
+++ b/src/integration-tests/test-programs/BrokenSO_main.c
@@ -1,0 +1,5 @@
+extern void a(void);
+
+int main(void) {
+    a();
+}

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -56,6 +56,13 @@ MultiThread: MultiThread.o
 MultiThreadRunControl: MultiThreadRunControl.o
 	$(LINK_CXX)
 
+# See https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/239#issuecomment-1411173434
+BrokenSO: BrokenSO_libsomea.c BrokenSO_libsomeb.c BrokenSO_main.c Makefile
+	gcc -shared -o libsomea.so -fPIC -g3 BrokenSO_libsomea.c
+	gcc -shared -o libsomeb.so -fPIC -g3 BrokenSO_libsomeb.c
+	gcc -o BrokenSO BrokenSO_main.c -g3 -L. -lsomea
+	mv libsomeb.so libsomea.so
+
 %.o: %.c
 	$(CC) -c $< -g3 -O0
 

--- a/src/integration-tests/test-programs/empty.c
+++ b/src/integration-tests/test-programs/empty.c
@@ -1,4 +1,9 @@
 int main()
 {
-    return 0;
+    int var1 = 234;
+    int arr1[] = {5, 6, 7, 8};
+    for (int i = 0; i < 4; i++) {
+        var1 += arr1[i];
+    }
+    return var1;
 }


### PR DESCRIPTION
This is based on the usecase described in #239 and will form the basis of a test to make sure we don't lose such error messages.

To show the error in GDB outside of the adapter, do this:

```sh
$ make BrokenSO
gcc -shared -o libsomea.so -fPIC -g3 BrokenSO_libsomea.c
gcc -shared -o libsomeb.so -fPIC -g3 BrokenSO_libsomeb.c
gcc -o BrokenSO BrokenSO_main.c -g3 -L. -lsomea
mv libsomeb.so libsomea.so

$ LD_LIBRARY_PATH=$PWD gdb --quiet BrokenSO
Reading symbols from BrokenSO...
(gdb) b main
Breakpoint 1 at 0x1151: file BrokenSO_main.c, line 4.
(gdb) r
Starting program: /scratch/debug/git/cdt-gdb-adapter/src/integration-tests/test-programs/BrokenSO
/scratch/debug/git/cdt-gdb-adapter/src/integration-tests/test-programs/BrokenSO: symbol lookup error: /scratch/debug/git/cdt-gdb-adapter/src/integration-tests/test-programs/BrokenSO: undefined symbol: a
[Inferior 1 (process 212237) exited with code 0177]
(gdb)
```