### PR TITLE
Increase visibility of internal timeouts

### DIFF
--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -63,7 +63,7 @@ describe('breakpoints', async function () {
         while (!isCorrect) {
             // Cover the case of getting event in Linux environment.
             // If cannot get correct event, program timeout and test case failed.
-            outputs = await dc.waitForEvent('output', this.timeout());
+            outputs = await dc.waitForEvent('output');
             isCorrect = outputs.body.output.includes('breakpoint-modified');
         }
         let substring: string;

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -52,8 +52,11 @@ export class CdtDebugClient extends DebugClient {
         if (extraArgs) {
             this._cdt_args.push(...extraArgs);
         }
-        // These timeouts should match what is in .mocharc.json and .mocharc-windows-ci.json
-        this.defaultTimeout = os.platform() === 'win32' ? 25000 : 5000;
+        // These timeouts should be smaller than what is in .mocharc.json and .mocharc-windows-ci.json
+        // to allow the individual timeouts to fail before the whole test timesout.
+        // This will mean error message on things such as waitForEvent will not
+        // be hidden by overall test failure
+        this.defaultTimeout = os.platform() === 'win32' ? 25000 / 2 : 5000 / 2;
     }
 
     /**

--- a/src/integration-tests/functionBreakpoints.spec.ts
+++ b/src/integration-tests/functionBreakpoints.spec.ts
@@ -57,7 +57,7 @@ describe('function breakpoints', async function () {
         while (!isCorrect) {
             // Cover the case of getting event in Linux environment.
             // If cannot get correct event, program timeout and test case failed.
-            outputs = await dc.waitForEvent('output', this.timeout());
+            outputs = await dc.waitForEvent('output');
             isCorrect = outputs.body.output.includes('breakpoint-modified');
         }
         let substring: string;


### PR DESCRIPTION
Because test timeouts normally timeout before timeouts on things like `waitForEvent` error messages lose useful information.

Therefore reduce the default timeout on indivdual events.

This changes an error from something like:

```
Error: Timeout of 5000ms exceeded. For async
tests and hooks, ensure "done()" is called;
if returning a Promise, ensure it resolves.
```

to something like:

```
Error: no event 'terminated' received after 2500 ms
```