### PR TITLE
Fix attach to process (non-remote case)

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -350,6 +350,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         await this.gdb.sendEnablePrettyPrint();
 
         if (request === 'attach') {
+            this.isAttach = true;
             const attachArgs = args as AttachRequestArguments;
             await mi.sendTargetAttachRequest(this.gdb, {
                 pid: attachArgs.processId,

--- a/src/integration-tests/attach.spec.ts
+++ b/src/integration-tests/attach.spec.ts
@@ -1,0 +1,54 @@
+/*********************************************************************
+ * Copyright (c) 2023 Kichwa Coders and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import { AttachRequestArguments } from '../GDBDebugSession';
+import { CdtDebugClient } from './debugClient';
+import {
+    fillDefaults,
+    isRemoteTest,
+    standardBeforeEach,
+    testProgramsDir,
+} from './utils';
+import { expect } from 'chai';
+
+describe('attach', function () {
+    let dc: CdtDebugClient;
+    let inferior: cp.ChildProcess;
+    const program = path.join(testProgramsDir, 'loopforever');
+    const src = path.join(testProgramsDir, 'loopforever.c');
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach();
+        inferior = cp.spawn(program, ['running-from-spawn'], {
+            cwd: testProgramsDir,
+        });
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+        inferior.kill();
+    });
+
+    it('can attach and hit a breakpoint', async function () {
+        if (isRemoteTest) {
+            // attachRemote.spec.ts is the test for when isRemoteTest
+            this.skip();
+        }
+
+        const attachArgs = fillDefaults(this.test, {
+            program: program,
+            processId: `${inferior.pid}`,
+        } as AttachRequestArguments);
+        await dc.attachHitBreakpoint(attachArgs, { line: 25, path: src });
+        expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
+    });
+});

--- a/src/integration-tests/test-programs/empty.c
+++ b/src/integration-tests/test-programs/empty.c
@@ -1,4 +1,4 @@
-int main()
+int main(int argc, char *argv[])
 {
     return 0;
 }

--- a/src/integration-tests/test-programs/loopforever.c
+++ b/src/integration-tests/test-programs/loopforever.c
@@ -12,7 +12,7 @@ int inner2(void) {
     return var2++;
 }
 
-int main()
+int main(int argc, char *argv[])
 {
     time_t start_time = time(NULL);
     while (stop == 0) {


### PR DESCRIPTION
The bug was that when doing an attach, an -exec-run would be done regardless. This meant that the already attached to process would be terminated and a new inferior would be created.

This was a regression introduced in 1893eb89150d34977ad9eaf0e806b22f3d66f0cd

To verify that the correct inferior is being communicated with I pass a command line argument to the process to be attached. After attaching I then verify the argv of the process has that command line argument.

Includes improvements to the debugClient test code to allow attachRequest to be sent as part of a connection sequence. Includes a new evaluate method to make it a one liner to check the value of an expression from a test.

Fixes #244