### PR TITLE
Implement inferior in its own terminal on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "dependencies": {
     "@vscode/debugadapter": "^1.48.0",
     "@vscode/debugprotocol": "^1.48.0",
-    "node-addon-api": "^4.3.0"
+    "node-addon-api": "^4.3.0",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -81,7 +82,6 @@
     "node-gyp": "^8.4.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.5.1",
-    "tmp": "^0.2.1",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.5"
   },


### PR DESCRIPTION
Using DAP's runInTerminal this PR adds the ability to use that new terminal for the inferior's I/O.

The basic idea of the inferior terminal on Linux is:

- adapter requests client (aka vscode) to create a terminal (using runInTerminal)
- in that terminal we run a small script that "returns" the tty name to the adapter (using an atomically created file with the output of tty command)
- then the script waits until the adapter is complete by monitoring the PID of the adapter's node process

The script run in the terminal won't auto-stop when running the adapter in server mode (typically should only be used for development of the adapter)

Part of #161