### PR TITLE
Support terminate request in debug adapter

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1551,6 +1551,10 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await this.gdb.sendGDBExit();
+            // Delay 5 ms to wait for GDB server to be terminated completely
+            if(_args.restart){
+                await new Promise((res) => setTimeout(res, 5000));
+            }
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -192,10 +192,16 @@ export class GDBDebugSession extends LoggingDebugSession {
     // therefore be resumed after breakpoints are inserted.
     protected waitPausedNeeded = false;
     protected isInitialized = false;
+    protected capabilities: {
+        supportsTerminateRequest: boolean;
+    };
 
     constructor() {
         super();
         this.logger = logger;
+        this.capabilities = {
+            supportsTerminateRequest: true,
+        };
     }
 
     /**
@@ -313,6 +319,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         response.body.supportsDisassembleRequest = true;
         response.body.supportsReadMemoryRequest = true;
         response.body.supportsWriteMemoryRequest = true;
+        response.body.supportsTerminateRequest = true;
         this.sendResponse(response);
     }
 

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1551,10 +1551,6 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await this.gdb.sendGDBExit();
-            // Delay 5 ms to wait for GDB server to be terminated completely
-            if(_args.restart){
-                await new Promise((res) => setTimeout(res, 5000));
-            }
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -18,7 +18,6 @@ import {
 import * as mi from './mi';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { spawn, ChildProcess } from 'child_process';
-import { exec } from 'child_process';
 
 export interface TargetAttachArguments {
     // Target type default is "remote"


### PR DESCRIPTION
When restart request is called, the disconnectRequest() and launchRequest() will be called. In the disconnectRequest() will send a '-gdb-exit' command to exit GDB server then the launch method will be called to start a new GDB server. But LaunchRequest() is not wait for GDB server is terminated completely to run and start a new GDB server. In this case, Emulator is still being held by old GDB server, So cannot start a new GDB server. Solution: Make a delay to wait for GDB server is terminated completely.