### PR TITLE
Update status of multi threads in Call Stack View

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1007,9 +1007,6 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await mi.sendExecContinue(this.gdb, args.threadId);
-            response.body = {
-                allThreadsContinued: false,
-            }
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -989,7 +989,12 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await mi.sendExecContinue(this.gdb, args.threadId);
-            const isAllThreadsContinued = args.threadId ? false : true;
+            let isAllThreadsContinued;
+            if (this.gdb.isNonStopMode()) {
+                isAllThreadsContinued = args.threadId ? false : true;
+            } else {
+                isAllThreadsContinued = true;
+            }
             response.body = {
                 allThreadsContinued: isAllThreadsContinued,
             }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -23,7 +23,6 @@ import {
     Source,
     StackFrame,
     TerminatedEvent,
-    Event,
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { GDBBackend } from './GDBBackend';
@@ -113,23 +112,6 @@ export interface CDTDisassembleArguments
      * is used.
      */
     endMemoryReference: string;
-}
-
-export class ContinuedEvent
-    extends Event
-    implements DebugProtocol.ContinuedEvent
-{
-    public body: {
-        /** The thread which was continued. */
-        threadId: number;
-        /** If 'allThreadsContinued' is true, a debug adapter can announce that all threads have continued. */
-        allThreadsContinued?: boolean;
-    };
-
-    constructor(threadId: number, allThreadsContinued: boolean) {
-        super('continued');
-        this.body = { threadId, allThreadsContinued };
-    }
 }
 
 class ThreadWithStatus implements DebugProtocol.Thread {
@@ -1007,6 +989,10 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await mi.sendExecContinue(this.gdb, args.threadId);
+            const isAllThread = args.threadId ? false : true;
+            response.body = {
+                allThreadsContinued: isAllThread,
+            }
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(
@@ -1590,14 +1576,6 @@ export class GDBDebugSession extends LoggingDebugSession {
         // Send the event
         this.sendEvent(new StoppedEvent(reason, threadId, allThreadsStopped));
     }
-    
-    protected sendContinuedEvent(
-        threadId: number,
-        allThreadsStopped: boolean
-    ) {
-        // Send the event
-        this.sendEvent(new ContinuedEvent(threadId, allThreadsStopped));
-    }
 
     protected handleGDBStopped(result: any) {
         const getThreadId = (resultData: any) =>
@@ -1674,13 +1652,11 @@ export class GDBDebugSession extends LoggingDebugSession {
                     for (const thread of this.threads) {
                         if (thread.id === id) {
                             thread.running = true;
-                            this.sendContinuedEvent(thread.id, false);
                         }
                     }
                 } else {
                     for (const thread of this.threads) {
                         thread.running = true;
-                        this.sendContinuedEvent(thread.id, false);
                     }
                 }
                 updateIsRunning();
@@ -1731,7 +1707,9 @@ export class GDBDebugSession extends LoggingDebugSession {
                     (this.gdb.isNonStopMode() ||
                         (wasRunning && !this.isRunning))
                 ) {
-                    this.handleGDBStopped(resultData);
+                    if (this.isInitialized) {
+                        this.handleGDBStopped(resultData);
+                    }
                 }
                 break;
             }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -989,9 +989,9 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             await mi.sendExecContinue(this.gdb, args.threadId);
-            const isAllThread = args.threadId ? false : true;
+            const isAllThreadsContinued = args.threadId ? false : true;
             response.body = {
-                allThreadsContinued: isAllThread,
+                allThreadsContinued: isAllThreadsContinued,
             }
             this.sendResponse(response);
         } catch (err) {

--- a/src/integration-tests/continues.spec.ts
+++ b/src/integration-tests/continues.spec.ts
@@ -1,0 +1,56 @@
+/*********************************************************************
+ * Copyright (c) 2018 QNX Software Systems and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { CdtDebugClient } from './debugClient';
+import {
+    standardBeforeEach,
+    fillDefaults,
+    testProgramsDir,
+    getScopes,
+    gdbNonStop
+} from './utils';
+import { expect } from 'chai';
+import * as path from 'path';
+
+describe('continues', async function() {
+    let dc: CdtDebugClient;
+
+    beforeEach(async function() {
+        dc = await standardBeforeEach();
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program: path.join(testProgramsDir, 'count'),
+            })
+        );
+    });
+
+    afterEach(async function() {
+        await dc.stop();
+    });
+
+    it.only('handles continues single-thread', async function() {
+        await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                },
+            ],
+        });
+        await dc.configurationDoneRequest();
+        await dc.waitForEvent('stopped');
+        const scope = await getScopes(dc);
+        const continueResponse = await dc.continueRequest({ threadId: scope.thread.id });
+        expect(continueResponse.body.allThreadsContinued).to.eq(!gdbNonStop);
+    });
+});

--- a/src/integration-tests/continues.spec.ts
+++ b/src/integration-tests/continues.spec.ts
@@ -34,7 +34,7 @@ describe('continues', async function() {
         await dc.stop();
     });
 
-    it.only('handles continues single-thread', async function() {
+    it('handles continues single-thread', async function() {
         await dc.setBreakpointsRequest({
             source: {
                 name: 'count.c',


### PR DESCRIPTION
For multiple cores debugging, the state of cores is not updated correctly with the state in the GDB server. Cannot use "Resume" or "Suspend" button in case of multiple cores debugging. That has not happened in cdt-amalgamator. This solution refers to cdt-amalgamator repository.

Root cause: Call Stack View does not update the state RUNNING if the process *Initialize* is not completed. cdt-gdb-adapter does not support sending "ContinuedEvent" when GDB returns async message "running"

Solution: Return Continues Response with the arg "allThreadsContinued" is 'false', which makes all threads not set to "RUNNING" state. Send ContinuedEvent when handling async message "running" from the GDB server. Remove the condition that does not send StoppedEvent if the process Initialize is not completed.