### PR TITLE
Support kill() process when GDB does not exit

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -371,7 +371,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         }
     }
 
-    public async exitGDBServer(isKillProcess: boolean): Promise<void> {
+    protected async exitGDBServer(isKillProcess: boolean): Promise<void> {
         if (this.isServerTerminated) {
             return;
         }


### PR DESCRIPTION
Following the discussion in PR #256
I would like to commit the new change about it. I think it is easy to review because the change is different from #256

Solution: Override disconnectRequest() with option exitGDBServer() if this request does not use for restart Request. It has some benefits:
1. disconnectRequest does not wait over 2 seconds for response. exitGDBServer() will handle separately with the request. 
2. restartRequest will be implemented in RenesasGDBTargetDebugSession, that mean it is not depended on timeout of others Request.
3. does not need to implement terminateRequest because it seems cannot update CallStack view when GDB exited.