### PR TITLE
Support Debug Console interacting directly with GDB

### DIFF
--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -79,4 +79,46 @@ describe('evaluate request', function () {
 
         expect(err.message).eq('-var-create: unable to create variable object');
     });
+    it('should be able to update the value of a variable named monitor and that variable has local scope', async function () {
+        const res1 = await dc.evaluateRequest({
+            context: 'repl',
+            expression: 'monitor = 10',
+            frameId: scope.frame.id,
+        });
+
+        expect(res1.body.result).eq('10');
+        const res2 = await dc.evaluateRequest({
+            context: 'repl',
+            expression: 'monitor',
+            frameId: scope.frame.id,
+        });
+        expect(res2.body.result).eq('10');
+    });
+    it('should be able to use GDB command', async function () {
+        const res1 = await dc.evaluateRequest({
+            context: 'repl',
+            expression: '>help',
+            frameId: scope.frame.id,
+        });
+
+        expect(res1.body.result).eq('\r');
+        const res2 = await dc.evaluateRequest({
+            context: 'repl',
+            expression: '>-gdb-version',
+            frameId: scope.frame.id,
+        });
+
+        expect(res2.body.result).eq('\r');
+    });
+    it('should reject entering an invalid MI command', async function () {
+        const err = await expectRejection(
+            dc.evaluateRequest({
+                context: 'repl',
+                expression: '>-a',
+                frameId: scope.frame.id,
+            })
+        );
+
+        expect(err.message).eq('Undefined MI command: a');
+    });
 });

--- a/src/integration-tests/test-programs/evaluate.cpp
+++ b/src/integration-tests/test-programs/evaluate.cpp
@@ -1,3 +1,7 @@
 int main() {
+    int monitor = 0;
+    while(monitor < 1000){
+        monitor++;
+    }
     return 0;
 }

--- a/src/mi/index.ts
+++ b/src/mi/index.ts
@@ -15,3 +15,4 @@ export * from './stack';
 export * from './target';
 export * from './thread';
 export * from './var';
+export * from './interpreter';

--- a/src/mi/interpreter.ts
+++ b/src/mi/interpreter.ts
@@ -1,0 +1,22 @@
+/*********************************************************************
+ * Copyright (c) 2018 QNX Software Systems and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { GDBBackend } from '../GDBBackend';
+export function sendInterpreterExecConsole(
+    gdb: GDBBackend,
+    params: {
+        threadId: number;
+        frameId: number;
+        command: any;
+    }
+) {
+    return gdb.sendCommand(
+        `-interpreter-exec --thread ${params.threadId} --frame ${params.frameId} console "${params.command}"`
+    );
+}


### PR DESCRIPTION
This change adds the ability to interact with GDB directly in the debug console of VSCode by providing a way to bypass the normal expression evaluation and sending commands to the GDB console input.

To display the value of an expression, type that expression which can reference variables that are in scope. For example type `2 + 3` or the name of a variable. Arbitrary commands can be sent to GDB by prefixing the input with a `>`, for example type `>show version` or `>help`.