### PR TITLE
The incorrect state of multicore in Call Stack View

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -861,19 +861,12 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             if (!this.isRunning) {
-                const result = await mi.sendThreadInfoRequest(this.gdb, {});
-                const threadMapInfo = result.threads.map((self) =>
-                    this.convertThread(self)
-                );
-                this.threads.map((thread) => {
-                    const threadInfo = threadMapInfo.find(
-                        (self) => self.id === thread.id
-                    );
-                    if (threadInfo !== undefined) {
-                        thread.name = threadInfo.name;
-                        thread.running = threadInfo.running;
-                    }
-                });
+                if (!this.isRunning) {
+                    const result = await mi.sendThreadInfoRequest(this.gdb, {});
+                    this.threads = result.threads.map((thread) =>
+                        this.convertThread(thread)
+                    ).sort((a, b) => a.id - b.id);
+                }
             }
 
             response.body = {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -863,7 +863,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             const result = await mi.sendThreadInfoRequest(this.gdb, {});
             this.threads = result.threads.map((thread) =>
                 this.convertThread(thread)
-            ).sort((a, b) => a.id - b.id);
+            ).sort((a, b) => a.id - b.id); 
 
             response.body = {
                 threads: this.threads,

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -860,12 +860,10 @@ export class GDBDebugSession extends LoggingDebugSession {
         response: DebugProtocol.ThreadsResponse
     ): Promise<void> {
         try {
-            if (!this.isRunning) {
-                const result = await mi.sendThreadInfoRequest(this.gdb, {});
-                this.threads = result.threads.map((thread) =>
-                    this.convertThread(thread)
-                ).sort((a, b) => a.id - b.id);
-            }
+            const result = await mi.sendThreadInfoRequest(this.gdb, {});
+            this.threads = result.threads.map((thread) =>
+                this.convertThread(thread)
+            ).sort((a, b) => a.id - b.id);
 
             response.body = {
                 threads: this.threads,

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -860,10 +860,12 @@ export class GDBDebugSession extends LoggingDebugSession {
         response: DebugProtocol.ThreadsResponse
     ): Promise<void> {
         try {
-            const result = await mi.sendThreadInfoRequest(this.gdb, {});
-            this.threads = result.threads.map((thread) =>
-                this.convertThread(thread)
-            ).sort((a, b) => a.id - b.id); 
+            if (!this.isRunning) {
+                const result = await mi.sendThreadInfoRequest(this.gdb, {});
+                this.threads = result.threads.map((thread) =>
+                    this.convertThread(thread)
+                ).sort((a, b) => a.id - b.id);
+            }
 
             response.body = {
                 threads: this.threads,

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -862,9 +862,18 @@ export class GDBDebugSession extends LoggingDebugSession {
         try {
             if (!this.isRunning) {
                 const result = await mi.sendThreadInfoRequest(this.gdb, {});
-                this.threads = result.threads.map((thread) =>
-                    this.convertThread(thread)
+                const threadMapInfo = result.threads.map((self) =>
+                    this.convertThread(self)
                 );
+                this.threads.map((thread) => {
+                    const threadInfo = threadMapInfo.find(
+                        (self) => self.id === thread.id
+                    );
+                    if (threadInfo !== undefined) {
+                        thread.name = threadInfo.name;
+                        thread.running = threadInfo.running;
+                    }
+                });
             }
 
             response.body = {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -861,12 +861,10 @@ export class GDBDebugSession extends LoggingDebugSession {
     ): Promise<void> {
         try {
             if (!this.isRunning) {
-                if (!this.isRunning) {
-                    const result = await mi.sendThreadInfoRequest(this.gdb, {});
-                    this.threads = result.threads.map((thread) =>
-                        this.convertThread(thread)
-                    ).sort((a, b) => a.id - b.id);
-                }
+                const result = await mi.sendThreadInfoRequest(this.gdb, {});
+                this.threads = result.threads.map((thread) =>
+                    this.convertThread(thread)
+                ).sort((a, b) => a.id - b.id);
             }
 
             response.body = {


### PR DESCRIPTION
When starting multicore with debugger type "amalgamator", the state of multicore was displayed in Call Stack View is incorrect.

Due to difference about the information of thread got from threadsRequest, the order of threads to store information for corresponding core at initialization and when got from GDB server is different.

So, the state of multicore was displayed in Call Stack View are incorrectly updated.