### PR TITLE
Improvements for Breakpoint Logic

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -165,6 +165,17 @@ export class GDBBackend extends events.EventEmitter {
         return this.gdbNonStop;
     }
 
+    // getBreakpointOptions called before inserting the breakpoint and this
+    // method could overridden in derived classes to dynamically control the
+    // breakpoint insert options. If an error thrown from this method, then
+    // the breakpoint will not be inserted.
+    public async getBreakpointOptions(
+        _: mi.MIBreakpointLocation,
+        initialOptions: mi.MIBreakpointInsertOptions
+    ): Promise<mi.MIBreakpointInsertOptions> {
+        return initialOptions;
+    }
+
     public isUseHWBreakpoint() {
         return this.hardwareBreakpoint;
     }

--- a/src/integration-tests/dynamicBreakpointOptions.spec.ts
+++ b/src/integration-tests/dynamicBreakpointOptions.spec.ts
@@ -1,0 +1,156 @@
+/*********************************************************************
+ * Copyright (c) 2023 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import * as path from 'path';
+import * as os from 'os';
+import { expect } from 'chai';
+import { CdtDebugClient } from './debugClient';
+import { standardBeforeEach, testProgramsDir, fillDefaults } from './utils';
+
+// This mock adapter is overriding the getBreakpointOptions method.
+const adapter =
+    'integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.js';
+const argHardwareBreakpointTrue = '--hardware-breakpoint-true';
+const argHardwareBreakpointFalse = '--hardware-breakpoint-false';
+const argThrowError = '--throw-error';
+
+describe('dynamic breakpoint options with hardware set to false', async () => {
+    let dc: CdtDebugClient;
+
+    beforeEach(async function () {
+        // Overriding breakpoint option hardware to false
+        dc = await standardBeforeEach(adapter, [argHardwareBreakpointFalse]);
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program: path.join(testProgramsDir, 'count'),
+                hardwareBreakpoint: true,
+            })
+        );
+    });
+
+    afterEach(async () => {
+        await dc.stop();
+    });
+
+    it('insert breakpoint as software breakpoint', async () => {
+        const bpResp = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                },
+            ],
+        });
+        expect(bpResp.body.breakpoints.length).eq(1);
+        expect(bpResp.body.breakpoints[0].verified).eq(true);
+        expect(bpResp.body.breakpoints[0].message).eq(undefined);
+        await dc.configurationDoneRequest();
+        let isCorrect;
+        let outputs;
+        while (!isCorrect) {
+            // Cover the case of getting event in Linux environment.
+            // If cannot get correct event, program timeout and test case failed.
+            outputs = await dc.waitForEvent('output');
+            isCorrect = outputs.body.output.includes('breakpoint-modified');
+        }
+        expect(outputs?.body.output).includes('type="breakpoint"');
+    });
+});
+
+describe('dynamic breakpoint options with hardware set to true', async () => {
+    let dc: CdtDebugClient;
+
+    beforeEach(async function () {
+        // Overriding breakpoint option hardware to true
+        dc = await standardBeforeEach(adapter, [argHardwareBreakpointTrue]);
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program: path.join(testProgramsDir, 'count'),
+                hardwareBreakpoint: false,
+            })
+        );
+    });
+
+    afterEach(async () => {
+        await dc.stop();
+    });
+
+    it('insert breakpoint as hardware breakpoint', async function () {
+        // Hardware breakpoints are not supported for Windows
+        if (os.platform() === 'win32') {
+            this.skip();
+        }
+        const bpResp = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                },
+            ],
+        });
+        expect(bpResp.body.breakpoints.length).eq(1);
+        expect(bpResp.body.breakpoints[0].verified).eq(true);
+        expect(bpResp.body.breakpoints[0].message).eq(undefined);
+        await dc.configurationDoneRequest();
+        let isCorrect;
+        let outputs;
+        while (!isCorrect) {
+            // Cover the case of getting event in Linux environment.
+            // If cannot get correct event, program timeout and test case failed.
+            outputs = await dc.waitForEvent('output');
+            isCorrect = outputs.body.output.includes('breakpoint-modified');
+        }
+        expect(outputs?.body.output).includes('type="hw breakpoint"');
+    });
+});
+
+describe('dynamic breakpoint options with throwing error', async () => {
+    let dc: CdtDebugClient;
+
+    beforeEach(async function () {
+        // Overriding breakpoint options and throwing error when getBreakpointOptions invoked
+        dc = await standardBeforeEach(adapter, [argThrowError]);
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program: path.join(testProgramsDir, 'count'),
+                hardwareBreakpoint: false,
+            })
+        );
+    });
+
+    afterEach(async () => {
+        await dc.stop();
+    });
+
+    it('insert breakpoint is not performed', async () => {
+        const bpResp = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                },
+            ],
+        });
+        expect(bpResp.body.breakpoints.length).eq(1);
+        expect(bpResp.body.breakpoints[0].verified).eq(false);
+        expect(bpResp.body.breakpoints[0].message).not.eq(undefined);
+    });
+});

--- a/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
+++ b/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/*********************************************************************
+ * Copyright (c) 2023 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import * as process from 'process';
+import { logger } from '@vscode/debugadapter/lib/logger';
+import { GDBBackend } from '../../../GDBBackend';
+import { GDBTargetDebugSession } from '../../../GDBTargetDebugSession';
+import { MIBreakpointLocation, MIBreakpointInsertOptions } from '../../../mi';
+
+process.on('uncaughtException', (err: any) => {
+    logger.error(JSON.stringify(err));
+});
+
+// Breakpoint options to override
+const hardwareBreakpointTrue = process.argv.includes(
+    '--hardware-breakpoint-true'
+);
+const hardwareBreakpointFalse = process.argv.includes(
+    '--hardware-breakpoint-false'
+);
+const throwError = process.argv.includes('--throw-error');
+
+class DynamicBreakpointOptionsGDBBackend extends GDBBackend {
+    public async getBreakpointOptions(
+        _: MIBreakpointLocation,
+        initialOptions: MIBreakpointInsertOptions
+    ): Promise<MIBreakpointInsertOptions> {
+        if (throwError) {
+            throw new Error(
+                'Some error message providing information that the breakpoint is not valid!'
+            );
+        }
+        const hardware = hardwareBreakpointTrue
+            ? true
+            : hardwareBreakpointFalse
+            ? false
+            : initialOptions.hardware;
+        return { ...initialOptions, hardware };
+    }
+}
+
+class DynamicBreakpointOptionsGDBDebugSession extends GDBTargetDebugSession {
+    gdb = this.createBackend();
+    protected createBackend(): GDBBackend {
+        return new DynamicBreakpointOptionsGDBBackend();
+    }
+}
+
+DynamicBreakpointOptionsGDBDebugSession.run(
+    DynamicBreakpointOptionsGDBDebugSession
+);


### PR DESCRIPTION
Hi Eclipse GDB Adapter Team,

Here in this update, we tried to improve the breakpoint logic of the cdt-gdb-adapter to provide capability to dynamically control the breakpoint options in runtime. 

The idea came from a problem we encounter during the insert breakpoint operation, finally we want to introduce a new feature where breakpoint options could be dynamically handled by derived classes of GDBBackend (especially type of breakpoint [hardware/software] for our case).

Through this update, we introduce a new method getBreakpointOptions to GDBBackend class. With this new functionality, any derived class of GDBBackend could override the breakpoint options.

We believe this will improve user experience in embedded systems by managing the limited breakpoint capability more efficiently. Besides, any error thrown in the getBreakpointOptions if no more breakpoints are available in the device will automatically disable the breakpoint in VSCode user interface; and by already implemented nature of the cdt-gdb-adapter if one of the breakpoints are removed, the next available breakpoint is enabled automatically. 

There are also some refactoring performed during the operation. Perhaps, not all the refactorings are must to have, but we tried to handle the namings of functions/methods and object structure to be semantically coherent after the update.

Please review this update in your suitable time and let us know if you have feedbacks. We will be happy if you consider this update and merge to the project main stream.

Kind regards
Asim Gunes