### PR TITLE
Support terminateThreadsRequest and handle GDB notify after thread group existed

### DIFF
--- a/src/mi/interpreter.ts
+++ b/src/mi/interpreter.ts
@@ -20,3 +20,14 @@ export function sendInterpreterExecConsole(
         `-interpreter-exec --thread ${params.threadId} --frame ${params.frameId} console "${params.command}"`
     );
 }
+
+export function sendInterpreterExecThreadGroupKill(
+    gdb: GDBBackend,
+    params: {
+        threadGroupId: number;
+    }
+) {
+    return gdb.sendCommand(
+        `-interpreter-exec --thread-group i${params.threadGroupId} console kill`
+    );
+}


### PR DESCRIPTION
Currently, when users use terminate threads in Callstack view, this does not work. So, we need to support terminate thread request to handle this case.