### PR TITLE
Adding the ability to configure serial port output to the debug console

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: '14'
       - name: Install GCC & GDB & other build essentials
         run: |
-          sudo apt-get -y install build-essential gcc g++ gdb gdbserver
+          sudo apt-get -y install build-essential gcc g++ gdb gdbserver socat
           gdb --version
           gcc --version
           gdbserver --version

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: '14'
       - name: Install GCC & GDB & other build essentials
         run: |
-          sudo apt-get -y install build-essential gcc g++ gdb gdbserver
+          sudo apt-get -y install build-essential gcc g++ gdb gdbserver socat
           gdb --version
           gcc --version
           gdbserver --version

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   "dependencies": {
     "@vscode/debugadapter": "^1.59.0",
     "@vscode/debugprotocol": "^1.59.0",
-    "node-addon-api": "^4.3.0"
+    "node-addon-api": "^4.3.0",
+    "serialport": "11.0.0",
+    "@types/serialport": "8.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "@vscode/debugadapter": "^1.59.0",
     "@vscode/debugprotocol": "^1.59.0",
     "node-addon-api": "^4.3.0",
-    "serialport": "11.0.0",
-    "@types/serialport": "8.0.2"
+    "serialport": "11.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
@@ -70,6 +69,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.18.17",
     "@types/tmp": "^0.2.3",
+    "@types/serialport": "8.0.2",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "@vscode/debugadapter-testsupport": "^1.59.0",

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1776,7 +1776,6 @@ export class GDBDebugSession extends LoggingDebugSession {
             case 'library-loaded':
             case 'breakpoint-modified':
             case 'breakpoint-deleted':
-            case 'cmd-param-changed':
                 // Known unhandled notifies
                 break;
             default:

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1776,6 +1776,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             case 'library-loaded':
             case 'breakpoint-modified':
             case 'breakpoint-deleted':
+            case 'cmd-param-changed':
                 // Known unhandled notifies
                 break;
             default:

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -495,7 +495,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     ): Promise<void> {
         try {
             try {
-                SerialPort.close();
+                if (SerialPort.isOpen) SerialPort.close();
             } catch (err) {
                 logger.error((err as Error).message);
             }

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -18,46 +18,8 @@ import {
 import * as mi from './mi';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { spawn, ChildProcess } from 'child_process';
-import * as net from "net";
-import * as serialport from "serialport";
-
-/**
- * This is a placeholder for the serial port. We assign the correct serial
- * port path below in "startGDBAndAttachToTarget" if it is specified.
- * Defining this variable here allows us to properly close the serial port
- * on debug finish.
- * Additionally, set autoOpen to false to prevent the serial port from being
- * opened automatically.
- */
-let SerialPort: serialport.SerialPort = new serialport.SerialPort({
-    path: "COM",
-    baudRate: 115200,
-    autoOpen: false
-});
-
-
-/**
- * This is a placeholder for the socket. We assign the correct socket
- * port path below in "startGDBAndAttachToTarget" if it is specified.
- */
-const socket = new net.Socket();
-socket.setEncoding("utf-8");
-
-let tcpUartData = "";
-socket.on("data", (data: string) => {
-    for (const char of data) {
-        if (char === "\n") {
-            logger.log(tcpUartData);
-            tcpUartData = "";
-        } else{
-            tcpUartData += char;
-        }
-    }
-});
-socket.on("close", () => {
-    logger.log(tcpUartData);
-    logger.warn("CLOSING SOCKET...");
-});
+import{ SerialPort, ReadlineParser } from "serialport";
+import { Socket } from "net";
 
 export interface TargetAttachArguments {
     // Target type default is "remote"
@@ -71,20 +33,23 @@ export interface TargetAttachArguments {
     port?: string;
     // Target connect commands - if specified used in preference of type, parameters, host, target
     connectCommands?: string[];
-    // Path to the serial port connected to the UART on the board.
-    uartSerialPort?: string;
-    // Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)
-    uartSocketPort?: string;
-    // Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).
-    baudRate?: number;
-    // The number of bits in each character of data sent across the serial line (defaults to 8).
-    characterSize?: (5 | 6 | 7 | 8);
-    // The type of parity check enabled with the transmitted data (defaults to "none" - no parity bit sent)
-    parity?: ("none" | "even" | "odd" | "mark" | "space");
-    // The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).
-    stopBits?: (1 | 1.5 | 2);
-    // The handshaking method used for flow control across the serial line (defaults to "none" - no handshaking)
-    handshakingMethod?: ("none" | "XON/XOFF" | "RTS/CTS");
+    // Settings related to displaying UART output in the debug console
+    uart?: {
+        // Path to the serial port connected to the UART on the board.
+        serialPort?: string;
+        // Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)
+        socketPort?: string;
+        // Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).
+        baudRate?: number;
+        // The number of bits in each character of data sent across the serial line (defaults to 8).
+        characterSize?: (5 | 6 | 7 | 8);
+        // The type of parity check enabled with the transmitted data (defaults to "none" - no parity bit sent)
+        parity?: ("none" | "even" | "odd" | "mark" | "space");
+        // The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).
+        stopBits?: (1 | 1.5 | 2);
+        // The handshaking method used for flow control across the serial line (defaults to "none" - no handshaking)
+        handshakingMethod?: ("none" | "XON/XOFF" | "RTS/CTS");
+    }
 }
 
 export interface TargetLaunchArguments extends TargetAttachArguments {
@@ -133,6 +98,18 @@ export interface TargetLaunchRequestArguments
 export class GDBTargetDebugSession extends GDBDebugSession {
     protected gdbserver?: ChildProcess;
     protected killGdbServer = true;
+
+    /**
+     * Define the target type here such that we can run the "disconnect"
+     * command when servicing the disconnect request if the target type
+     * is remote.
+     */
+    protected targetType?: string;
+
+    // Serial Port to capture UART output across the serial line
+    protected serialPort?: SerialPort;
+    // Socket to listen on a TCP port to capture UART output
+    protected socket?: Socket;
 
     protected async attachOrLaunchRequest(
         response: DebugProtocol.Response,
@@ -200,7 +177,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
     protected setupCommonLoggerAndHandlers(args: TargetLaunchRequestArguments) {
         logger.setup(
-            args.verbose ? Logger.LogLevel.Verbose : Logger.LogLevel.Log,
+            args.verbose ? Logger.LogLevel.Verbose : Logger.LogLevel.Warn,
             args.logFile || false
         );
 
@@ -347,7 +324,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             }
 
             if (target.connectCommands === undefined) {
-                const targetType =
+                this.targetType =
                     target.type !== undefined ? target.type : 'remote';
                 let defaultTarget: string[];
                 if (target.port !== undefined) {
@@ -364,12 +341,12 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                         ? target.parameters
                         : defaultTarget;
                 await mi.sendTargetSelectRequest(this.gdb, {
-                    type: targetType,
+                    type: this.targetType,
                     parameters: targetParameters,
                 });
                 this.sendEvent(
                     new OutputEvent(
-                        `connected to ${targetType} target ${targetParameters.join(
+                        `connected to ${this.targetType} target ${targetParameters.join(
                             ' '
                         )}`
                     )
@@ -385,69 +362,134 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
             await this.gdb.sendCommands(args.initCommands);
 
-            if (target.uartSerialPort) {
-                try {
-                    // Set the path to the serial port
-                    SerialPort = new serialport.SerialPort({
-                        path: target.uartSerialPort,
-                        // If the serial port path is defined, then so will the baud rate.
-                        baudRate: target.baudRate ?? 115200,
-                        // If the serial port path is deifned, then so will the number of data bits.
-                        dataBits: target.characterSize ?? 8,
-                        // If the serial port path is defined, then so will the number of stop bits.
-                        stopBits: target.stopBits ?? 1,
-                        // If the serial port path is defined, then so will the parity check type.
-                        parity: target.parity ?? 'none',
-                        // If the serial port path is defined, then so will the type of handshaking method.
-                        rtscts:
-                            target.handshakingMethod === 'RTS/CTS'
-                                ? true
-                                : false,
-                        xon:
-                            target.handshakingMethod === 'XON/XOFF'
-                                ? true
-                                : false,
-                        xoff:
-                            target.handshakingMethod === 'XON/XOFF'
-                                ? true
-                                : false,
-                        autoOpen: false,
-                    });
+            if (target.uart !== undefined) {
+                if (target.uart.serialPort !== undefined) {
+                    try {
+                        // Set the path to the serial port
+                        this.serialPort = new SerialPort({
+                            path: target.uart.serialPort,
+                            // If the serial port path is defined, then so will the baud rate.
+                            baudRate: target.uart.baudRate ?? 115200,
+                            // If the serial port path is deifned, then so will the number of data bits.
+                            dataBits: target.uart.characterSize ?? 8,
+                            // If the serial port path is defined, then so will the number of stop bits.
+                            stopBits: target.uart.stopBits ?? 1,
+                            // If the serial port path is defined, then so will the parity check type.
+                            parity: target.uart.parity ?? 'none',
+                            // If the serial port path is defined, then so will the type of handshaking method.
+                            rtscts:
+                                target.uart.handshakingMethod === 'RTS/CTS'
+                                    ? true
+                                    : false,
+                            xon:
+                                target.uart.handshakingMethod === 'XON/XOFF'
+                                    ? true
+                                    : false,
+                            xoff:
+                                target.uart.handshakingMethod === 'XON/XOFF'
+                                    ? true
+                                    : false,
+                            autoOpen: false,
+                        });
 
-                    SerialPort.on("open", () => {
-                        logger.warn(`LISTENING ON SERIAL PORT ${target.uartSerialPort}...\n`);
-                    });
+                        this.serialPort.on("open", () => {
+                            this.sendEvent(
+                                new OutputEvent(
+                                    `listening on serial port ${this.serialPort?.path}`,
+                                    "Serial Port"
+                                )
+                            );
+                        });
 
-                    const SerialUartParser = new serialport.ReadlineParser({
-                        delimiter: "\n",
-                        encoding: "utf8"
-                    });
+                        const SerialUartParser = new ReadlineParser({
+                            delimiter: "\n",
+                            encoding: "utf8"
+                        });
 
-                    SerialPort.pipe(SerialUartParser).on("data", (line: string) => {
-                        logger.log(line);
-                    });
+                        this.serialPort.pipe(SerialUartParser).on("data", (line: string) => {
+                            this.sendEvent(
+                                new OutputEvent(line, "Serial Port")
+                            );
+                        });
 
-                    SerialPort.on("close", () => {
-                        logger.warn("CLOSING SERIAL PORT...\n");
-                    });
+                        this.serialPort.on("close", () => {
+                            this.sendEvent(
+                                new OutputEvent(
+                                    "closing serial port connection",
+                                    "Serial Port"
+                                )
+                            );
+                        });
 
-                    SerialPort.open();
-                } catch (err) {
-                    logger.error((err as Error).message);
-                }
-            } else if (target.uartSocketPort) {
-                try {
-                    socket.connect(
-                        // Putting a + (unary plus operator) infront of the string converts it to a number.
-                        +target.uartSocketPort,
-                        // Default to localhost if target.host is undefined.
-                        target.host ?? "localhost",
-                        () => {
-                            logger.warn(`LISTENING ON TCP PORT ${target.uartSocketPort}`);
-                        }
-                    );
-                } catch (err) {
-                    logger.error((err as Error).message);
+                        this.serialPort.open();
+                    } catch (err) {
+                        this.sendErrorResponse(
+                            response,
+                            1,
+                            err instanceof Error ? err.message : String(err)
+                        );
+                    }
+                } else if (target.uart.socketPort !== undefined) {
+                    try {
+                        /**
+                         * This is a placeholder for the socket. We assign the correct socket
+                         * port path below in "startGDBAndAttachToTarget" if it is specified.
+                         */
+                        this.socket = new Socket();
+                        this.socket.setEncoding("utf-8");
+
+                        let tcpUartData = "";
+                        this.socket.on("data", (data: string) => {
+                            for (const char of data) {
+                                if (char === "\n") {
+                                    this.sendEvent(
+                                        new OutputEvent(
+                                            tcpUartData,
+                                            "Socket"
+                                        )
+                                    )
+                                    tcpUartData = "";
+                                } else{
+                                    tcpUartData += char;
+                                }
+                            }
+                        });
+                        this.socket.on("close", () => {
+                            this.sendEvent(
+                                new OutputEvent(
+                                    tcpUartData,
+                                    "Socket"
+                                )
+                            );
+                            this.sendEvent(
+                                new OutputEvent(
+                                    "closing socket connection",
+                                    "Socket"
+                                )
+                            );
+                        });
+
+                        this.socket.connect(
+                            // Putting a + (unary plus operator) infront of the string converts it to a number.
+                            +target.uart.socketPort,
+                            // Default to localhost if target.host is undefined.
+                            target.host ?? "localhost",
+                            () => {
+                                this.sendEvent(
+                                    new OutputEvent(
+                                        `listening on tcp port ${target.uart?.socketPort}`,
+                                        "Socket"
+                                    )
+                                );
+                            }
+                        );
+                    } catch (err) {
+                        this.sendErrorResponse(
+                            response,
+                            1,
+                            err instanceof Error ? err.message : String(err)
+                        );
+                    }
                 }
             }
 
@@ -463,7 +505,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             this.sendEvent(new InitializedEvent());
             this.sendResponse(response);
             this.isInitialized = true;
-            logger.warn("STARTING DEBUG...\n");
+            this.sendEvent(
+                new OutputEvent(
+                    "starting debug"
+                )
+            );
         } catch (err) {
             this.sendErrorResponse(
                 response,
@@ -495,9 +541,20 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     ): Promise<void> {
         try {
             try {
-                if (SerialPort.isOpen) SerialPort.close();
+                if (
+                    this.serialPort !== undefined &&
+                    this.serialPort.isOpen
+                )
+                    this.serialPort.close();
             } catch (err) {
-                logger.error((err as Error).message);
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
+            }
+            if (this.targetType === "remote") {
+                await this.gdb.sendCommand("disconnect");
             }
             await this.gdb.sendGDBExit();
             if (this.killGdbServer) {

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -398,7 +398,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             });
-            console.log(uart.socketPort);
             this.socket.connect(
                 // Putting a + (unary plus operator) infront of the string converts it to a number.
                 +uart.socketPort,

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -99,13 +99,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     protected gdbserver?: ChildProcess;
     protected killGdbServer = true;
 
-    /**
-     * Define the target type here such that we can run the "disconnect"
-     * command when servicing the disconnect request if the target type
-     * is remote.
-     */
-    protected targetType?: string;
-
     // Serial Port to capture UART output across the serial line
     protected serialPort?: SerialPort;
     // Socket to listen on a TCP port to capture UART output
@@ -324,7 +317,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             }
 
             if (target.connectCommands === undefined) {
-                this.targetType =
+                const targetType =
                     target.type !== undefined ? target.type : 'remote';
                 let defaultTarget: string[];
                 if (target.port !== undefined) {
@@ -341,12 +334,12 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                         ? target.parameters
                         : defaultTarget;
                 await mi.sendTargetSelectRequest(this.gdb, {
-                    type: this.targetType,
+                    type: targetType,
                     parameters: targetParameters,
                 });
                 this.sendEvent(
                     new OutputEvent(
-                        `connected to ${this.targetType} target ${targetParameters.join(
+                        `connected to ${targetType} target ${targetParameters.join(
                             ' '
                         )}`
                     )
@@ -552,9 +545,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     1,
                     err instanceof Error ? err.message : String(err)
                 );
-            }
-            if (this.targetType === "remote") {
-                await this.gdb.sendCommand("disconnect");
             }
             await this.gdb.sendGDBExit();
             if (this.killGdbServer) {

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -366,7 +366,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             this.socket = new Socket();
             this.socket.setEncoding("utf-8");
 
-            let eolChar: string = uart.eolCharacter === "LF" ? "\n" : "\r\n";
+            const eolChar: string = uart.eolCharacter === "LF" ? "\n" : "\r\n";
 
             let tcpUartData = "";
             this.socket.on("data", (data: string) => {
@@ -398,7 +398,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             });
-
+            console.log(uart.socketPort);
             this.socket.connect(
                 // Putting a + (unary plus operator) infront of the string converts it to a number.
                 +uart.socketPort,

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -377,27 +377,19 @@ export class CdtDebugClient extends DebugClient {
      * @param category catgory of output event from socket server
      * @param output expected output coming from socket server
      */
-    public getSocketOutput(
-        attachArgs: any,
+    public async getSocketOutput(
+        launchArgs: any,
         category: string,
         output: string
     ): Promise<any> {
         return Promise.all([
-            this.waitForEvent('initialized')
-                .then((_event) => {
-                    return this.waitForOutputEvent(
-                        category,
-                        output
-                    );
-                })
-                .then((response) => {
-                    expect(response.body.category).to.equal(category);
-                    expect(response.body.category).to.equal(output);
-                }),
-
-            this.initializeRequest().then((_response) => {
-                return this.attachRequest(attachArgs);
-            }),
+            this.waitForEvent('initialized'),
+            this.launch(launchArgs).then((_event) => {
+                return this.waitForOutputEvent(
+                    category,
+                    output
+                );
+            })
         ]);
     }
 }

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -373,11 +373,11 @@ export class CdtDebugClient extends DebugClient {
     }
 
     /**
-     * Obtain the output coming from the socket server.
-     * @param category catgory of output event from socket server
-     * @param output expected output coming from socket server
+     * Obtain the output coming from the debug console..
+     * @param category catgory of output event coming on debug console.
+     * @param output expected output coming on debug console
      */
-    public async getSocketOutput(
+    public async getDebugConsoleOutput(
         launchArgs: any,
         category: string,
         output: string

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -384,9 +384,8 @@ export class CdtDebugClient extends DebugClient {
     ): Promise<any> {
         return Promise.all([
             this.waitForEvent('initialized'),
-            this.launch(launchArgs).then((_event) => {
-                return this.waitForOutputEvent(category, output);
-            }),
+            this.launch(launchArgs),
+            this.waitForOutputEvent(category, output),
         ]);
     }
 }

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -371,6 +371,35 @@ export class CdtDebugClient extends DebugClient {
         });
         return evalResponse.body.result;
     }
+
+    /**
+     * Obtain the output coming from the socket server.
+     * @param category catgory of output event from socket server
+     * @param output expected output coming from socket server
+     */
+    public getSocketOutput(
+        attachArgs: any,
+        category: string,
+        output: string
+    ): Promise<any> {
+        return Promise.all([
+            this.waitForEvent('initialized')
+                .then((_event) => {
+                    return this.waitForOutputEvent(
+                        category,
+                        output
+                    );
+                })
+                .then((response) => {
+                    expect(response.body.category).to.equal(category);
+                    expect(response.body.category).to.equal(output);
+                }),
+
+            this.initializeRequest().then((_response) => {
+                return this.attachRequest(attachArgs);
+            }),
+        ]);
+    }
 }
 
 /**

--- a/src/integration-tests/debugClient.ts
+++ b/src/integration-tests/debugClient.ts
@@ -385,11 +385,8 @@ export class CdtDebugClient extends DebugClient {
         return Promise.all([
             this.waitForEvent('initialized'),
             this.launch(launchArgs).then((_event) => {
-                return this.waitForOutputEvent(
-                    category,
-                    output
-                );
-            })
+                return this.waitForOutputEvent(category, output);
+            }),
         ]);
     }
 }

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -48,37 +48,37 @@ describe('launch remote', function () {
 
     it('can print a message to the debug console sent from a socket server', async function () {
         const socketServer = cp.spawn(
-            "node",
-            [`${path.join(testProgramsDir, "socketServer.js")}`],
+            'node',
+            [`${path.join(testProgramsDir, 'socketServer.js')}`],
             {
                 cwd: testProgramsDir,
             }
         );
         // Ensure that the socket port is defined prior to the test.
-        let socketPort = "";
-        socketServer.stdout.on("data", (data) => {
+        let socketPort = '';
+        socketServer.stdout.on('data', (data) => {
             socketPort = data.toString();
-            socketPort = socketPort.substring(0, socketPort.indexOf("\n"));
+            socketPort = socketPort.substring(0, socketPort.indexOf('\n'));
         });
 
         // Sleep for 1 second before running test to ensure socketPort is defined.
-        await new Promise(f => setTimeout(f, 1000));
-        expect(socketPort).not.eq("");
+        await new Promise((f) => setTimeout(f, 1000));
+        expect(socketPort).not.eq('');
 
         await dc.getSocketOutput(
             fillDefaults(this.test, {
                 program: emptyProgram,
                 openGdbConsole: false,
-                initCommands: ["break _fini"],
+                initCommands: ['break _fini'],
                 target: {
                     uart: {
                         socketPort: socketPort,
-                        eolCharacter: "LF"
-                    }
-                } as TargetLaunchArguments
+                        eolCharacter: 'LF',
+                    },
+                } as TargetLaunchArguments,
             } as TargetLaunchRequestArguments),
-            "Socket",
-            "Hello World!"
-        )
+            'Socket',
+            'Hello World!'
+        );
     });
 });

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -43,4 +43,31 @@ describe('launch remote', function () {
             }
         );
     });
+
+    it('can print a message to the debug console sent from a socket server', async function () {
+        dc.getSocketOutput(
+            fillDefaults(this.test, {
+                program: emptyProgram,
+                openGdbConsole: false,
+                initCommands: ["shell echo \"Hello World!\" | nc -l 3456 &"],
+                preRunCommands: ["disconnect"],
+                target: {
+                    "host": "localhost",
+                    "port": "9899",
+                    "server": "gdbserver",
+                    "serverParameters": [
+                        "--once",
+                        "localhost:9899",
+                        emptyProgram
+                    ],
+                    "uart": {
+                        "socketPort": "3456",
+                        "eolCharacter": "LF"
+                    }
+                } as TargetLaunchArguments
+            } as TargetLaunchRequestArguments),
+            "Socket",
+            "Hello World!"
+        )
+    });
 });

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -81,6 +81,9 @@ describe('launch remote', function () {
             'Socket',
             'Hello World!'
         );
+
+        // Kill the spawned process.
+        socketServer.kill();
     });
 
     it('can print a message to the debug console sent from across a serial line', async function () {
@@ -88,7 +91,7 @@ describe('launch remote', function () {
         if (os.platform() === 'win32') this.skip();
 
         // Start a virtual serial line. Use /tmp/ttyV0 and /tmp/ttyV1 to refer to the two ends.
-        cp.spawn('socat', [
+        const virtualSerialLine = cp.spawn('socat', [
             '-d',
             '-d',
             'pty,rawer,echo=0,link=/tmp/ttyV0',
@@ -112,5 +115,8 @@ describe('launch remote', function () {
             'Serial Port',
             'Hello World!'
         );
+
+        // Kill the spawned process.
+        virtualSerialLine.kill();
     });
 });

--- a/src/integration-tests/test-programs/socketServer.js
+++ b/src/integration-tests/test-programs/socketServer.js
@@ -1,0 +1,32 @@
+const net = require('net');
+
+// Create socket echo server.
+const socketServer = new net.Server();
+
+socketServer.on("connection", (connection) => {
+    console.log("adapter connected");
+
+    connection.on("end", () => {
+        console.log("adapter disconected");
+    });
+
+    // Echo "Hello World!"
+    connection.write("Hello World!\n");
+});
+
+socketServer.on("close", () => {
+    console.log("shutting down");
+})
+
+socketServer.on("error", (error) => {
+    throw error;
+});
+
+function serverListen() {
+    socketServer.listen(0, "localhost", 1, () => {
+        const port = (socketServer.address()).port;
+        console.log(`${port}`);
+    });
+}
+
+serverListen();

--- a/src/integration-tests/test-programs/socketServer.js
+++ b/src/integration-tests/test-programs/socketServer.js
@@ -1,30 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const net = require('net');
 
 // Create socket echo server.
 const socketServer = new net.Server();
 
-socketServer.on("connection", (connection) => {
-    console.log("adapter connected");
+socketServer.on('connection', (connection) => {
+    console.log('adapter connected');
 
-    connection.on("end", () => {
-        console.log("adapter disconected");
+    connection.on('end', () => {
+        console.log('adapter disconected');
     });
 
     // Echo "Hello World!"
-    connection.write("Hello World!\n");
+    connection.write('Hello World!\n');
 });
 
-socketServer.on("close", () => {
-    console.log("shutting down");
-})
+socketServer.on('close', () => {
+    console.log('shutting down');
+});
 
-socketServer.on("error", (error) => {
+socketServer.on('error', (error) => {
     throw error;
 });
 
 function serverListen() {
-    socketServer.listen(0, "localhost", 1, () => {
-        const port = (socketServer.address()).port;
+    socketServer.listen(0, 'localhost', 1, () => {
+        const port = socketServer.address().port;
         console.log(`${port}`);
     });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,8 @@
       }
     ]
   },
-  "include": ["src/**/*.ts", "src/integration-tests/test-programs/socketServer.js"]
+  "include": [
+    "src/**/*.ts",
+    "src/integration-tests/test-programs/socketServer.js"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
       }
     ]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/integration-tests/test-programs/socketServer.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,6 +108,102 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@serialport/binding-mock@10.2.2":
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/@serialport/binding-mock/-/binding-mock-10.2.2.tgz#d322a8116a97806addda13c62f50e73d16125874"
+  integrity sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==
+  dependencies:
+    "@serialport/bindings-interface" "^1.2.1"
+    debug "^4.3.3"
+
+"@serialport/bindings-cpp@11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@serialport/bindings-cpp/-/bindings-cpp-11.0.1.tgz#38afa6105ceb7888c6a2af2782822fca9130d65a"
+  integrity sha512-3I1mniVg3osYuIUXxU0jB5AHPsxWmErmc3JC3WfUSlfXsjWMHkHfFzbW9Scuv/z/6DLCJIDyltabRa2FoW2qsQ==
+  dependencies:
+    "@serialport/bindings-interface" "1.2.2"
+    "@serialport/parser-readline" "10.5.0"
+    debug "4.3.4"
+    node-addon-api "6.1.0"
+    node-gyp-build "4.6.0"
+
+"@serialport/bindings-interface@1.2.2", "@serialport/bindings-interface@^1.2.1":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz#c4ae9c1c85e26b02293f62f37435478d90baa460"
+  integrity sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==
+
+"@serialport/parser-byte-length@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-byte-length/-/parser-byte-length-11.0.0.tgz#074e6ed6b18d7a61edc75dba22d3115e8f37dd8c"
+  integrity sha512-rExsdFKdzOIHOBqTwzxUF1A9nrluVIZKZOtvMq5i0Hc3euooGdmkx0VXYNRlI2rd6kJLTL2P+uIR+ZtCTRyT+w==
+
+"@serialport/parser-cctalk@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-cctalk/-/parser-cctalk-11.0.0.tgz#6a5e2b299e8f1ef00308980e45ecdae23825181e"
+  integrity sha512-eN1MvEIFwI4GedWJhte6eWF+NZtrjchZbMf0CE6NV9TRzJI1KLnFf90ZOj/mhGuANojX4sqWfJKQXwN6E8VSHQ==
+
+"@serialport/parser-delimiter@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz#b0d93100cdfd0619d020a427d652495073f3b828"
+  integrity sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==
+
+"@serialport/parser-delimiter@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-delimiter/-/parser-delimiter-11.0.0.tgz#e830c6bb49723d4446131277dc3243b502d09388"
+  integrity sha512-aZLJhlRTjSmEwllLG7S4J8s8ctRAS0cbvCpO87smLvl3e4BgzbVgF6Z6zaJd3Aji2uSiYgfedCdNc4L6W+1E2g==
+
+"@serialport/parser-inter-byte-timeout@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-11.0.0.tgz#baf7223bf3d49d159c82386928c763bfecf8f70f"
+  integrity sha512-RLgqZC50IET6FtEIt6Oi0vdRsesSBWLNwB7ldzR9OzyXKgK0XHRzqKqbB0u5Q+tC5OScdWeiQ2AO6jooKUZtsw==
+
+"@serialport/parser-packet-length@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-packet-length/-/parser-packet-length-11.0.0.tgz#ec06934b40b45b8f5eb04ba5527e98a1062c2a20"
+  integrity sha512-6ZkOiaCooabpV/EM7ttSRbisbDWpGEf7Yxyr13t28LicYR43THRdjdMZcRnWxEM/jpwfskkLLXAR6wziVpKrlw==
+
+"@serialport/parser-readline@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-readline/-/parser-readline-10.5.0.tgz#df23365ae7f45679b1735deae26f72ba42802862"
+  integrity sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==
+  dependencies:
+    "@serialport/parser-delimiter" "10.5.0"
+
+"@serialport/parser-readline@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-readline/-/parser-readline-11.0.0.tgz#c2c8c88e163d2abf7c0ffddbc1845336444e3454"
+  integrity sha512-rRAivhRkT3YO28WjmmG4FQX6L+KMb5/ikhyylRfzWPw0nSXy97+u07peS9CbHqaNvJkMhH1locp2H36aGMOEIA==
+  dependencies:
+    "@serialport/parser-delimiter" "11.0.0"
+
+"@serialport/parser-ready@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-ready/-/parser-ready-11.0.0.tgz#802e7189d9e5d13df70d3aa1559403b72fcfa700"
+  integrity sha512-lSsCPIctoc5kADCKnZDYBz1j69TsFqtnaWUicBzUAIAoUXpYKeYld8YX5NrvjViuVfIJeiqLZeGjxOWe5fqQqQ==
+
+"@serialport/parser-regex@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-regex/-/parser-regex-11.0.0.tgz#bb247297851b1a789f4dde1c4ad48c39d6db7ed6"
+  integrity sha512-aKuc/+/KE9swahTbYpSuOsQa7LggPx7jhfobJLPVVbAic80OpfCIY+MKr6Ax4R6UtQwF90O5Yk6OEmbbvtEmiA==
+
+"@serialport/parser-slip-encoder@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-slip-encoder/-/parser-slip-encoder-11.0.0.tgz#f1c3f56e04c497ca89059c69ea79411b30e8da60"
+  integrity sha512-3ZI/swd2it20vmu2tzqDbkyE4dqy+kExEDY6T33YQ210HDKPVhqj7FAVGo5P++MZ3dup1of11t4P9UPBNkuJnQ==
+
+"@serialport/parser-spacepacket@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/parser-spacepacket/-/parser-spacepacket-11.0.0.tgz#7737aaa1397db4bf820160dd2f7dd0c9df5f74a0"
+  integrity sha512-+hqRckrTEqz+/uAUZY0Tq6YIRyCl4oQOH1MeVzKiFiGNjZP7hDJCDoY7LTr9CeJhxvcT0ItTbtjGBqGumV8fxg==
+
+"@serialport/stream@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@serialport/stream/-/stream-11.0.0.tgz#9887db096b51fabe1919a591b920b06f7580e8ee"
+  integrity sha512-Zty7B8C1H2XRnay2mVmW1ygEHXRHXQDcaC5wAVvOZMbQSc7ye03rMlPvviDS+pGxU2t2A2bMo34CUrRduSBong==
+  dependencies:
+    "@serialport/bindings-interface" "1.2.2"
+    debug "4.3.4"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -169,6 +265,13 @@
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
+"@types/serialport@8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@types/serialport/-/serialport-8.0.2.tgz#32149f107f66450d4d9760c429923739c97e4a53"
+  integrity sha512-z4b1I8/vdZE3upgCcAL9VAWlVVFUVn5uo3faAHavkVfK/Hb1LUxKwp9YCtA5AZqEUCWoSWl20SRTOvAI/5fQWQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/tmp@^0.2.3":
   version "0.2.3"
@@ -1682,6 +1785,11 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
+node-gyp-build@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
+
 node-gyp@^8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
@@ -2034,6 +2142,26 @@ serialize-javascript@6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+serialport@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/serialport/-/serialport-11.0.0.tgz#a4114fc60e91b23f133ec459345b7be637b1e8ef"
+  integrity sha512-bxs3XejQcOHWpzPAaXMhxVRlbem6fjNUrux3ToqrGvFR6BcjOYhqE5CsHOuutv37kmhmnuHrn+/hN+1BpTmaFg==
+  dependencies:
+    "@serialport/binding-mock" "10.2.2"
+    "@serialport/bindings-cpp" "11.0.1"
+    "@serialport/parser-byte-length" "11.0.0"
+    "@serialport/parser-cctalk" "11.0.0"
+    "@serialport/parser-delimiter" "11.0.0"
+    "@serialport/parser-inter-byte-timeout" "11.0.0"
+    "@serialport/parser-packet-length" "11.0.0"
+    "@serialport/parser-readline" "11.0.0"
+    "@serialport/parser-ready" "11.0.0"
+    "@serialport/parser-regex" "11.0.0"
+    "@serialport/parser-slip-encoder" "11.0.0"
+    "@serialport/parser-spacepacket" "11.0.0"
+    "@serialport/stream" "11.0.0"
+    debug "4.3.4"
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR introduces a set of parameters that allow us to configure a serial line in the adapter to print UART output from on-board/emulation debug to the debug console. These parameters include the TCP port to hook onto (for emulation programs outputting UART output), or the serial port on the host machine to capture UART output from. For the serial line, we also configure the baud rate, stop bits, handshaking method, etc.

The source code looks to take these parameters to then configure serial ports and sockets to read UART data and output it to the debug console. It will also set up necessary event handlers, and changes the log level in the non-verbose case to allow for "log" messages to be printed in a manner such that UART output isn't designated as a "warning".

~Lastly, GDBDebugSession.ts features an addition to remove a warning about an "unhandled notify" for the cmd-param-changed notification.~ (this part moved to #272)