### PR TITLE
Resolve Unhandled Notify Warning

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -1776,6 +1776,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             case 'library-loaded':
             case 'breakpoint-modified':
             case 'breakpoint-deleted':
+            case 'cmd-param-changed':
                 // Known unhandled notifies
                 break;
             default:


### PR DESCRIPTION
This change resolves an "unhandled notify" warning coming when the cmd-param-changed notification is received.

To recreate this warning:
- In your initCommands, you can put something like "set mem inaccessible-by-default off" - this warning should appear in the debug log.

To check that this change resolves the warning:
- Re-run a debug session with the same initCommand above after applying the change.