### PR TITLE
Add support for escaped unicode characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "@vscode/debugadapter": "^1.59.0",
     "@vscode/debugprotocol": "^1.59.0",
     "node-addon-api": "^4.3.0",
-    "serialport": "11.0.0"
+    "serialport": "11.0.0",
+    "utf8": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
@@ -70,6 +71,7 @@
     "@types/node": "^14.18.17",
     "@types/serialport": "8.0.2",
     "@types/tmp": "^0.2.3",
+    "@types/utf8": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "@vscode/debugadapter-testsupport": "^1.59.0",

--- a/src/integration-tests/test-programs/.gitignore
+++ b/src/integration-tests/test-programs/.gitignore
@@ -19,3 +19,4 @@ MultiThreadRunControl
 /vars_cpp
 /log
 stderr
+bug275-测试

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -1,4 +1,4 @@
-BINS = empty empty\ space evaluate vars vars_cpp mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr
+BINS = empty empty\ space evaluate vars vars_cpp mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr bug275-测试
 
 .PHONY: all
 all: $(BINS)
@@ -27,6 +27,15 @@ count\ space.o: count\ space.c
 	$(CC) -c "count space.c" -g3 -O0
 
 empty: empty.o
+	$(LINK)
+
+# This is a workaround because make on Windows (on GitHub actions?) doesn't like
+# it otherwise
+bug275-测试.o: empty.c
+	cp empty.c bug275-测试.c
+	$(CC) -c bug275-测试.c -g3 -O0
+
+bug275-测试: bug275-测试.o
 	$(LINK)
 
 evaluate: evaluate.o

--- a/src/integration-tests/test-programs/bug275-测试.c
+++ b/src/integration-tests/test-programs/bug275-测试.c
@@ -1,0 +1,4 @@
+int main(int argc, char *argv[])
+{
+    return 0;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,11 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
   integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
 
+"@types/utf8@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/utf8/-/utf8-3.0.1.tgz#bf081663d4fff05ee63b41f377a35f8b189f7e5b"
+  integrity sha512-1EkWuw7rT3BMz2HpmcEOr/HL61mWNA6Ulr/KdbXR9AI0A55wD4Qfv8hizd8Q1DnknSIzzDvQmvvY/guvX7jjZA==
+
 "@typescript-eslint/eslint-plugin@^5.54.0":
   version "5.54.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz#2c821ad81b2c786d142279a8292090f77d1881f4"
@@ -2481,6 +2486,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
GDB is escaping unicode characters leading to the messages coming back from GDB not being understood correctly.

For example, hitting a breakpoint on issue-275-测试.c comes back from GDB as `file="issue-275-\346\265\213\350\257\225.c"` but by the time we send it to DAP client we are sending
`"name":"issue-275-346265213350257225.c"`

This patchset supports properly escaping these strings.

Fixes #275


TODO:

- [x] This is just a test so far that demonstrates the problem in #275, so the fix is needed
- [x] On Windows this doesn't build the example programs yet which have the unicode characters. That isn't an adapter problem, but a test problem.
- [x] Tom provided diagnosis of https://sourceware.org/bugzilla/show_bug.cgi?id=30618 and it looks like I can at least workaround the issue in the test