### PR TITLE
yarn format the code and enforce it in PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -40,6 +40,8 @@ jobs:
           name: test-results-ubuntu
           path: 'test-reports/*.xml'
           retention-days: 1
+      - name: Verify code formatting is valid
+        run: yarn format-check
   Build-on-Windows:
     name: Build & Test on Windows
     runs-on: windows-latest

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -862,9 +862,9 @@ export class GDBDebugSession extends LoggingDebugSession {
         try {
             if (!this.isRunning) {
                 const result = await mi.sendThreadInfoRequest(this.gdb, {});
-                this.threads = result.threads.map((thread) =>
-                    this.convertThread(thread)
-                ).sort((a, b) => a.id - b.id);
+                this.threads = result.threads
+                    .map((thread) => this.convertThread(thread))
+                    .sort((a, b) => a.id - b.id);
             }
 
             response.body = {

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -322,9 +322,9 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 });
                 this.sendEvent(
                     new OutputEvent(
-                        `connected to ${this.targetType} target ${targetParameters.join(
-                            ' '
-                        )}`
+                        `connected to ${
+                            this.targetType
+                        } target ${targetParameters.join(' ')}`
                     )
                 );
             } else {
@@ -380,8 +380,8 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         _args: DebugProtocol.DisconnectArguments
     ): Promise<void> {
         try {
-            if (this.targetType === "remote") {
-                await this.gdb.sendCommand("disconnect");
+            if (this.targetType === 'remote') {
+                await this.gdb.sendCommand('disconnect');
             }
             await this.gdb.sendGDBExit();
             if (this.killGdbServer) {

--- a/src/integration-tests/continues.spec.ts
+++ b/src/integration-tests/continues.spec.ts
@@ -13,15 +13,15 @@ import {
     fillDefaults,
     testProgramsDir,
     getScopes,
-    gdbNonStop
+    gdbNonStop,
 } from './utils';
 import { expect } from 'chai';
 import * as path from 'path';
 
-describe('continues', async function() {
+describe('continues', async function () {
     let dc: CdtDebugClient;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         dc = await standardBeforeEach();
         await dc.launchRequest(
             fillDefaults(this.currentTest, {
@@ -30,11 +30,11 @@ describe('continues', async function() {
         );
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
         await dc.stop();
     });
 
-    it('handles continues single-thread', async function() {
+    it('handles continues single-thread', async function () {
         await dc.setBreakpointsRequest({
             source: {
                 name: 'count.c',
@@ -50,7 +50,9 @@ describe('continues', async function() {
         await dc.configurationDoneRequest();
         await dc.waitForEvent('stopped');
         const scope = await getScopes(dc);
-        const continueResponse = await dc.continueRequest({ threadId: scope.thread.id });
+        const continueResponse = await dc.continueRequest({
+            threadId: scope.thread.id,
+        });
         expect(continueResponse.body.allThreadsContinued).to.eq(!gdbNonStop);
     });
 });


### PR DESCRIPTION
I accidentally let some unformatted code slip in, so lets try to enforce the formatting going forward