### PR TITLE
Make LF the default for UART eol characters

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -332,7 +332,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             });
 
             const SerialUartParser = new ReadlineParser({
-                delimiter: uart.eolCharacter === 'LF' ? '\n' : '\r\n',
+                delimiter: uart.eolCharacter === 'CRLF' ? '\r\n' : '\n',
                 encoding: 'utf8',
             });
 
@@ -356,7 +356,8 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             this.socket = new Socket();
             this.socket.setEncoding('utf-8');
 
-            const eolChar: string = uart.eolCharacter === 'LF' ? '\n' : '\r\n';
+            const eolChar: string =
+                uart.eolCharacter === 'CRLF' ? '\r\n' : '\n';
 
             let tcpUartData = '';
             this.socket.on('data', (data: string) => {


### PR DESCRIPTION
This fixes a bug introduced by #271 where the EOL character for UART output should have been LF, but was instead CRLF. See https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/91 for comments on this.