### PR TITLE
Add newline characters to every OutputEvent emitted regarding UART output

### DIFF
--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -79,7 +79,7 @@ describe('launch remote', function () {
                 } as TargetLaunchArguments,
             } as TargetLaunchRequestArguments),
             'Socket',
-            'Hello World!'
+            'Hello World!\n'
         );
 
         // Kill the spawned process.
@@ -113,7 +113,7 @@ describe('launch remote', function () {
                 } as TargetLaunchArguments,
             } as TargetLaunchRequestArguments),
             'Serial Port',
-            'Hello World!'
+            'Hello World!\n'
         );
 
         // Kill the spawned process.


### PR DESCRIPTION
This PR adds newlines to every OutputEvent emitted for UART output to the debug console. It matches the OS it is on + the eolCharacter specified in the launch.json. See https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/91 for an initial discussion on why this came to be.