### PR TITLE
Report errors on opening serial ports to Debug Console

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -354,6 +354,15 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 );
             });
 
+            this.serialPort.on('error', (err) => {
+                this.sendEvent(
+                    new OutputEvent(
+                        `error on serial port connection${os.EOL} - ${err}`,
+                        'Serial Port'
+                    )
+                );
+            });
+
             this.serialPort.open();
         } else if (uart.socketPort !== undefined) {
             this.socket = new Socket();

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -119,4 +119,23 @@ describe('launch remote', function () {
         // Kill the spawned process.
         virtualSerialLine.kill();
     });
+
+    it('can shows user error on debug console if UART fails to open', async function () {
+        const output = await dc.getDebugConsoleOutput(
+            fillDefaults(this.test, {
+                program: emptyProgram,
+                openGdbConsole: false,
+                initCommands: ['break _fini'],
+                target: {
+                    uart: {
+                        serialPort: '/mistake',
+                    },
+                } as TargetLaunchArguments,
+            } as TargetLaunchRequestArguments),
+            'Serial Port',
+            'error on serial port connection',
+            true
+        );
+        expect(output.body.output).contains('mistake');
+    });
 });


### PR DESCRIPTION
The new UART code can fail to open the UART and it leads to weird feedback.

The setup is to have a typo in the port:

```json
          "uart": {
            "serialPort": "/mistake",
          }
```

This leads to a `{}` in the debug console, here you see it while running verbose:

![image](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/assets/679236/d735dc43-ba70-4e1f-9c1e-9290ea4bfb41)

The underlying issue is lost because it is on node's output which gets interpreted by VSCode as DAP and it falls over a little here as a result. 

Running the adapter in server mode:

https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/92bb15046fea82256742a69f0b240129a1949a76/.vscode/launch.json#L16

and connecting to it with `"debugServer": 4711` in the `launch.json` shows what ended up on the output in the debug console:

![image](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/assets/679236/972e785f-892b-47ed-94fa-cb1ab92725d9)

The key part is:

```
(node:479803) UnhandledPromiseRejectionWarning: Error: Error: No such file or directory, cannot open /mistake
```

---

Therefore this PR adds error handling on serial port to make sure errors are passed back to the user.

