### PR TITLE
Send interrupt before disconnecting from remote

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -536,7 +536,9 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
             if (this.targetType === 'remote') {
                 // Ensure target is halted before disconnecting.
-                await this.gdb.sendCommand('interrupt');
+                this.gdb.pause();
+                // Set a 5 ms timeout to give time for GDB to pause.
+                await new Promise((t) => setTimeout(t, 5));
                 await this.gdb.sendCommand('disconnect');
             }
 

--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -535,6 +535,8 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 this.serialPort.close();
 
             if (this.targetType === 'remote') {
+                // Ensure target is halted before disconnecting.
+                await this.gdb.sendCommand('interrupt');
                 await this.gdb.sendCommand('disconnect');
             }
 


### PR DESCRIPTION
Ensure that for a remote target, an interrupt signal is sent before a disconnect request to ensure we only disconnect from a halted target.

This resolves an issue that, on remote targets, can be reproduced as follows:
1. Start a debug session inside VSCode, setting a breakpoint at a known location beforehand.
2. Continue after the breakpoint is hit
3. Stop the debug session.

The disconnect request errors out, returning the following error message:

"Cannot execute this command while the target is running. Use the 'interrupt' command to stop the target and then try again."

This results in the GDB Server not being killed, which can cause issues for future runs.

Note that this only happens when we continue after hitting a breakpoint and try to stop without pausing. If we never set a breakpoint to begin with, we can disconnect without pausing just fine.

@jonahgraham Please let me know if there needs to be a test written for this, and if so, how: I tried to look for a test case that deals with the disconnect request, but I couldn't find one.