### PR TITLE
Remove unnecessary `process` imports

### DIFF
--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -9,7 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import * as process from 'process';
 import { logger } from '@vscode/debugadapter/lib/logger';
 import { GDBDebugSession } from './GDBDebugSession';
 

--- a/src/debugTargetAdapter.ts
+++ b/src/debugTargetAdapter.ts
@@ -9,7 +9,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import * as process from 'process';
 import { logger } from '@vscode/debugadapter/lib/logger';
 import { GDBTargetDebugSession } from './GDBTargetDebugSession';
 

--- a/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
+++ b/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
@@ -8,7 +8,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import * as process from 'process';
 import { logger } from '@vscode/debugadapter/lib/logger';
 import { GDBBackend } from '../../../GDBBackend';
 import { GDBTargetDebugSession } from '../../../GDBTargetDebugSession';


### PR DESCRIPTION
When experimenting with bundling the CDT-GDB VSCode extension using ESBuild, I ran into a problem similar to [this one](https://github.com/evanw/esbuild/issues/587) that turned out to be due to the style of `process` imports used here. Since `process` is a Node global, the imports should be unnecessary, so this PR removes them.