### PR TITLE
Improved Error Handling for getAddr & sendCommand

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -2165,11 +2165,19 @@ export class GDBDebugSession extends LoggingDebugSession {
     }
 
     protected async getAddr(varobj: VarObjType) {
-        const addr = await mi.sendDataEvaluateExpression(
-            this.gdb,
-            `&(${varobj.expression})`
-        );
-        return addr.value ? addr.value : varobj.value;
+        let addr = undefined;
+        try {
+            addr = await mi.sendDataEvaluateExpression(
+                this.gdb,
+                `&(${varobj.expression})`
+            );
+        } catch (err) {
+            console.warn(
+                `Problem evaluating expression &(${varobj.expression}):\n`,
+                err
+            );
+        }
+        return addr?.value ? addr.value : varobj.value;
     }
 
     protected isChildOfClass(child: mi.MIVarChild): boolean {


### PR DESCRIPTION
If an array is optimized out, the 'getAddr' method of GDBDebugSession will fail so add try-catch.
Improve debugging of sendCommand by capturing the stack where the request originated instead of the stream read/parsing of message.