### PR TITLE
Ensure 'interrupt' signal is sent before 'disconnect' signal.

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -535,9 +535,18 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 this.serialPort.close();
 
             if (this.targetType === 'remote') {
-                if (this.gdb.getAsyncMode() && this.isRunning)
-                    this.gdb.sendCommand('interrupt');
-                await this.gdb.sendCommand('disconnect');
+                if (this.gdb.getAsyncMode() && this.isRunning) {
+                    // See #295 - this use of "then" is to try to slightly delay the
+                    // call to disconnect. A proper solution that waits for the
+                    // interrupt to be successful is needed to avoid future
+                    // "Cannot execute this command while the target is running"
+                    // errors
+                    this.gdb
+                        .sendCommand('interrupt')
+                        .then(() => this.gdb.sendCommand('disconnect'));
+                } else {
+                    await this.gdb.sendCommand('disconnect');
+                }
             }
 
             await this.gdb.sendGDBExit();


### PR DESCRIPTION
Hi @jonahgraham,

We tested @parisa-mchp's recent change ([PR #289](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/289)) by pulling version 0.0.102 from open-vsx.org, but we still encountered issues: Stopping the debugger while target is running doesn't disconnect the debugger properly. We found that this chunk of code is buggy. This happens in file `GDBTargetDebugSession.ts`, within method `disconnectRequest`:
```
            if (this.targetType === 'remote') {
                if (this.gdb.getAsyncMode() && this.isRunning)
                    this.gdb.sendCommand('interrupt');
                await this.gdb.sendCommand('disconnect');
            }
```
In the case where `this.gdb.getAsyncMode() && this.isRunning === true`, the 'disconnect' signal always gets sent before the 'interrupt' signal. The change in this PR is required to fix this issue.