### PR TITLE
Improve Call Stack Window Display

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -939,7 +939,10 @@ export class GDBDebugSession extends LoggingDebugSession {
                     threadId: args.threadId,
                     frameId: parseInt(frame.level, 10),
                 });
-                const name = frame.func || frame.fullname || '';
+                const name =
+                    frame.func && frame.func != '??'
+                        ? frame.func
+                        : frame.fullname || frame.addr || '';
                 const sf = new StackFrame(
                     frameHandle,
                     name,


### PR DESCRIPTION
Use the function name if available before falling back to fullname. This improves the use of space in the call stack in most cases since the function name is known.

This change:
![Ericsson_improvement_stackTraceRequest](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/assets/112585147/d91e2763-2a37-4943-8868-e7d6545dc00b)

Upstream with long form:
![Upstream_stackTraceRequest](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/assets/112585147/a6cf8375-b8e0-4dd8-9d1c-0fbbef51188b)
