### PR TITLE
Handle evaluate request for complex variables

### DIFF
--- a/src/integration-tests/test-programs/vars.c
+++ b/src/integration-tests/test-programs/vars.c
@@ -23,5 +23,7 @@ int main()
     int f[] = {1, 2, 3};
     int g = f[0] + f[1] + f[2]; // After array init
     int rax = 1;
+    const unsigned char h[] = {0x01, 0x10, 0x20};
+    const unsigned char k[] = "hello"; // char string setup
     return 0;
 }

--- a/src/integration-tests/test-programs/vars.c
+++ b/src/integration-tests/test-programs/vars.c
@@ -5,11 +5,18 @@ struct bar
     int b;
 };
 
+struct baz
+{
+    float w;
+    double v;
+};
+
 struct foo
 {
     int x;
     int y;
     struct bar z;
+    struct baz aa;
 };
 
 int main()
@@ -17,7 +24,7 @@ int main()
     int a = 1;
     int b = 2;
     int c = a + b; // STOP HERE
-    struct foo r = {1, 2, {3, 4}};
+    struct foo r = {1, 2, {3, 4}, {3.1415, 1234.5678}};
     int d = r.x + r.y;
     int e = r.z.a + r.z.b;
     int f[] = {1, 2, 3};

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -328,6 +328,15 @@ describe('Variables Test Suite', function () {
         verifyVariable(subChildren.body.variables[1], 'b', 'int', '4', {
             hasMemoryReference: false,
         });
+
+        // Evaluate the child structure foo.bar of r
+        const res = await dc.evaluateRequest({
+            context: 'variables',
+            expression: 'r.z',
+            frameId: scope.frame.id,
+        });
+        expect(res.body.result).eq('{...}');
+
         // set the variables to something different
         const setAinHex = await dc.setVariableRequest({
             name: 'a',


### PR DESCRIPTION
For simple variables, evaluateRequest() returns the value. 

For complex variables such as arrays and structures, a different representation is returned (arrays = `[sizeof(array)]`; structs = `{...}`). This PR adds the ability to evaluate a complex variable (at least 1 level deep) which is helpful for the variables context menu -> Copy Value command.

Adds some tests as well.