### PR TITLE
Add support for setting the cwd of the gdb process

### DIFF
--- a/src/integration-tests/gdbCwd.spec.ts
+++ b/src/integration-tests/gdbCwd.spec.ts
@@ -1,0 +1,125 @@
+/*********************************************************************
+ * Copyright (c) 2023 Kichwa Coders Canada Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as path from 'path';
+import { CdtDebugClient } from './debugClient';
+import {
+    fillDefaults,
+    resolveLineTagLocations,
+    standardBeforeEach,
+    testProgramsDir,
+} from './utils';
+import { expect } from 'chai';
+
+/**
+ * To test that cwd is set properly we remove the compilation directory from the executable,
+ * see the makefile for that part, and then launch with a variety of executable/cwd locations
+ * to make sure that we can insert breakpoints when we expect to, and cannot insert breakpoints
+ * when we force gdb not to be able to find the source
+ */
+describe('gdb cwd', function () {
+    let dc: CdtDebugClient;
+    const program = path.join(testProgramsDir, 'cwd.exe');
+    const programRelocated = path.join(testProgramsDir, 'Debug', 'cwd.exe');
+    const src = path.join(testProgramsDir, 'cwd.c');
+    const lineTags = {
+        'STOP HERE': 0,
+    };
+
+    before(function () {
+        resolveLineTagLocations(src, lineTags);
+    });
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach();
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    it('default cwd finds source in program directory', async function () {
+        await dc.launchRequest(
+            fillDefaults(this.test, {
+                program: program,
+            })
+        );
+
+        const bps = await dc.setBreakpointsRequest({
+            lines: [lineTags['STOP HERE']],
+            breakpoints: [{ line: lineTags['STOP HERE'], column: 1 }],
+            source: { path: src },
+        });
+        expect(bps.body.breakpoints[0].verified).to.eq(true);
+    });
+
+    it('explicit cwd finds source in program directory', async function () {
+        await dc.launchRequest(
+            fillDefaults(this.test, {
+                program: program,
+                cwd: testProgramsDir,
+            })
+        );
+
+        const bps = await dc.setBreakpointsRequest({
+            lines: [lineTags['STOP HERE']],
+            breakpoints: [{ line: lineTags['STOP HERE'], column: 1 }],
+            source: { path: src },
+        });
+        expect(bps.body.breakpoints[0].verified).to.eq(true);
+    });
+
+    it('default cwd does not find source with relocated program', async function () {
+        await dc.launchRequest(
+            fillDefaults(this.test, {
+                program: programRelocated,
+            })
+        );
+
+        const bps = await dc.setBreakpointsRequest({
+            lines: [lineTags['STOP HERE']],
+            breakpoints: [{ line: lineTags['STOP HERE'], column: 1 }],
+            source: { path: src },
+        });
+        expect(bps.body.breakpoints[0].verified).to.eq(false);
+    });
+
+    it('explicitly incorrect cwd does not finds source with relocated program', async function () {
+        await dc.launchRequest(
+            fillDefaults(this.test, {
+                program: programRelocated,
+                cwd: path.join(testProgramsDir, 'EmptyDir'),
+            })
+        );
+
+        const bps = await dc.setBreakpointsRequest({
+            lines: [lineTags['STOP HERE']],
+            breakpoints: [{ line: lineTags['STOP HERE'], column: 1 }],
+            source: { path: src },
+        });
+        expect(bps.body.breakpoints[0].verified).to.eq(false);
+    });
+
+    it('explicitly correct cwd does find source with relocated program', async function () {
+        await dc.launchRequest(
+            fillDefaults(this.test, {
+                program: programRelocated,
+                cwd: testProgramsDir,
+            })
+        );
+
+        const bps = await dc.setBreakpointsRequest({
+            lines: [lineTags['STOP HERE']],
+            breakpoints: [{ line: lineTags['STOP HERE'], column: 1 }],
+            source: { path: src },
+        });
+        expect(bps.body.breakpoints[0].verified).to.eq(true);
+    });
+});

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -1,4 +1,4 @@
-BINS = empty empty\ space evaluate vars vars_cpp vars_env mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr bug275-测试
+BINS = empty empty\ space evaluate vars vars_cpp vars_env mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr bug275-测试 cwd.exe
 
 .PHONY: all
 all: $(BINS)
@@ -25,6 +25,21 @@ count: count.o count_other.o count\ space.o
 
 count\ space.o: count\ space.c
 	$(CC) -c "count space.c" -g3 -O0
+
+# the cwd tests need to move around source and binary
+# in ways that mean gdb cannot find the source automatically
+# in the normal $cdir:$cwd and needs additional information
+# to be provided
+# debug-prefix-map used like this is to put an "incorrect"
+# DW_AT_comp_dir in the debug info
+cwd.o: cwd.c
+	$(CC) -fdebug-prefix-map=$(CURDIR)=.  -c $< -g3 -O0
+
+cwd.exe: cwd.o
+	$(LINK) -fdebug-prefix-map=$(CURDIR)=.
+	mkdir -p Debug
+	cp cwd.exe Debug
+	mkdir -p EmptyDir
 
 empty: empty.o
 	$(LINK)

--- a/src/integration-tests/test-programs/cwd.c
+++ b/src/integration-tests/test-programs/cwd.c
@@ -1,0 +1,4 @@
+int main(int argc, char *argv[])
+{
+    return 0; // STOP HERE
+}


### PR DESCRIPTION
For some use cases the executable being debugged expects to find its sources relative to the current working directory ($cwd) instead of the compilation directory ($cdir).

This can happen in a couple of circumstances:

1. The source and executable have been moved from the location it was compiled from.
2. The compiler did not save the compilation directory for the given file.

The compilation directory can be examined with "info source" in the GDB debugger console.