### PR TITLE
Set Prettier as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,11 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["EditorConfig.EditorConfig"],
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode"
+  ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,7 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": [
-    "editorconfig.editorconfig",
-    "esbenp.prettier-vscode"
-  ],
+  "recommendations": ["editorconfig.editorconfig", "esbenp.prettier-vscode"],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-  "eslint.packageManager": "yarn"
+  "eslint.packageManager": "yarn",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
As discussed in https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/309#issuecomment-1787800030, this adds Prettier to the recommendations and set it as the default formatter for this workspace.