### PR TITLE
Fix bug with parsing UART output

### DIFF
--- a/src/GDBTargetDebugSession.ts
+++ b/src/GDBTargetDebugSession.ts
@@ -391,15 +391,12 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             this.socket = new Socket();
             this.socket.setEncoding('utf-8');
 
-            const eolChar: string =
-                uart.eolCharacter === 'CRLF' ? '\r\n' : '\n';
-
             let tcpUartData = '';
             this.socket.on('data', (data: string) => {
                 for (const char of data) {
-                    if (char === eolChar) {
+                    if (char === '\n') {
                         this.sendEvent(
-                            new OutputEvent(tcpUartData + os.EOL, 'Socket')
+                            new OutputEvent(tcpUartData + '\n', 'Socket')
                         );
                         tcpUartData = '';
                     } else {

--- a/src/integration-tests/test-programs/socketServer.js
+++ b/src/integration-tests/test-programs/socketServer.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const net = require('net');
+const os = require('os');
 
 // Create socket echo server.
 const socketServer = new net.Server();
@@ -12,7 +13,7 @@ socketServer.on('connection', (connection) => {
     });
 
     // Echo "Hello World!"
-    connection.write('Hello World!\n');
+    connection.write(`Hello World!${os.EOL}`);
 });
 
 socketServer.on('close', () => {


### PR DESCRIPTION
This PR fixes _[issue #317](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/317)_.

Problematic code snippet in `GDBTargetDebugSession.ts`:
```
            const eolChar: string =
                uart.eolCharacter === 'CRLF' ? '\r\n' : '\n';

            let tcpUartData = '';
            this.socket.on('data', (data: string) => {
                for (const char of data) {
                    if (char === eolChar) {
                        this.sendEvent(
                            new OutputEvent(tcpUartData + os.EOL, 'Socket')
                        );
                        tcpUartData = '';
                    } else {
                        tcpUartData += char;
                    }
                }
            });
```
If `data` is `CoreTimer timer interrupt.\r\n` - for example - without setting `eolCharacter` in launch configuration, the adapter uses default `\n` to parse `data`. It accumulates `CoreTimer timer interrupt.\r` in variable `tcpUartData` and then appends `os.EOL` at the end. On Windows, the final `tcpUartData` becomes `CoreTimer timer interrupt.\r\r\n`. The extra new line comes from here. To fix this, the adapter appends `\n` instead of `\r\n` because `\r` is already in `tcpUartData`.

I tried setting `eolCharacter` to `CRLF` in launch configuration. This didn't work. `char` is one character in length, but `eolChar` is two in length, so `char === eolChar` is never `true`. The adapter also can't parse two characters at a time because one burst of `data` might be `CoreTimer timer interrupt.\r` and the next one `\n`. If this happens, `\r\n` will never be detected together.

I have tested this change fixes the problem I described in _[issue #317](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/317)_.