### PR TITLE
Ensure 'interrupt' and 'disconnect' signals are sent before '-gdb-exit'

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -472,17 +472,15 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
             if (this.targetType === 'remote') {
                 if (this.gdb.getAsyncMode() && this.isRunning) {
-                    // See #295 - this use of "then" is to try to slightly delay the
+                    // See #295 - this use of "await" is to try to slightly delay the
                     // call to disconnect. A proper solution that waits for the
                     // interrupt to be successful is needed to avoid future
                     // "Cannot execute this command while the target is running"
                     // errors
-                    this.gdb
-                        .sendCommand('interrupt')
-                        .then(() => this.gdb.sendCommand('disconnect'));
-                } else {
-                    await this.gdb.sendCommand('disconnect');
+                    await this.gdb.sendCommand('interrupt');
                 }
+
+                await this.gdb.sendCommand('disconnect');
             }
 
             await this.gdb.sendGDBExit();

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -327,17 +327,15 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         try {
             if (this.targetType === 'remote') {
                 if (this.gdb.getAsyncMode() && this.isRunning) {
-                    // See #295 - this use of "then" is to try to slightly delay the
+                    // See #295 - this use of "await" is to try to slightly delay the
                     // call to disconnect. A proper solution that waits for the
                     // interrupt to be successful is needed to avoid future
                     // "Cannot execute this command while the target is running"
                     // errors
-                    this.gdb
-                        .sendCommand('interrupt')
-                        .then(() => this.gdb.sendCommand('disconnect'));
-                } else {
-                    await this.gdb.sendCommand('disconnect');
+                    await this.gdb.sendCommand('interrupt');
                 }
+
+                await this.gdb.sendCommand('disconnect');
             }
 
             await this.gdb.sendGDBExit();


### PR DESCRIPTION
Previous PRs (i.e #292 and #289) do not include an `await` when sending interrupt/disconnect signals if the debugger is running. This causes the `-gdb-exit` command to be written and queued *before* the interrupt/disconnect signals.

An alternate, equivalent solution would look like:
```ts
await this.gdb
    .sendCommand('interrupt')
    .then(() => this.gdb.sendCommand('disconnect'));
```

I did read over https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/292#issuecomment-1721711960 and https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/292#issuecomment-1724176794. I'm not encountering any issues with using `await` instead of `.then`. I manually tested this on our IDE with `yield` operators, and it worked fine. After looking at `GDBBackend::sendCommand`, there doesn't seem to be any reason `await` doesn't work. The returned `Promise` does not resolve until the MI parser receives a response, which guarantees that the command was sent already (that tracks right?):
https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/44fda62259f04869495f8846c6e7abe9bb827b1a/src/gdb/GDBBackend.ts#L163-L196

If we decide to keep `.then`, there is still a missing `await` (as noted above in the equivalent solution).

As you noted in https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/292/files#r1330234785, this does not fix #295, but that issue is causing us some problems too, so I'll spend some time on that as well.