### PR TITLE
Add API to pause target and wait for debugger to be suspended

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -462,6 +462,10 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         });
     }
 
+    /**
+     * WARNING: `disconnectRequest` is unreliable in sync mode.
+     * @see {@link https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/339#discussion_r1840549671}
+     */
     protected async disconnectRequest(
         response: DebugProtocol.DisconnectResponse,
         _args: DebugProtocol.DisconnectArguments

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -471,14 +471,8 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 this.serialPort.close();
 
             if (this.targetType === 'remote') {
-                this.waitPausedNeeded =
-                    this.gdb.getAsyncMode() && this.isRunning;
-
-                if (this.waitPausedNeeded) {
-                    // Need to pause first, then disconnect and exit
-                    await this.pause();
-                }
-
+                // Need to pause first, then disconnect and exit
+                await this.pauseIfNeeded();
                 await this.gdb.sendCommand('disconnect');
             }
 

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -471,13 +471,12 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                 this.serialPort.close();
 
             if (this.targetType === 'remote') {
-                if (this.gdb.getAsyncMode() && this.isRunning) {
-                    // See #295 - this use of "await" is to try to slightly delay the
-                    // call to disconnect. A proper solution that waits for the
-                    // interrupt to be successful is needed to avoid future
-                    // "Cannot execute this command while the target is running"
-                    // errors
-                    await this.gdb.sendCommand('interrupt');
+                this.waitPausedNeeded =
+                    this.gdb.getAsyncMode() && this.isRunning;
+
+                if (this.waitPausedNeeded) {
+                    // Need to pause first, then disconnect and exit
+                    await this.pause();
                 }
 
                 await this.gdb.sendCommand('disconnect');

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -472,7 +472,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
             if (this.targetType === 'remote') {
                 // Need to pause first, then disconnect and exit
-                await this.pauseIfNeeded();
+                await this.pauseIfNeeded(true);
                 await this.gdb.sendCommand('disconnect');
             }
 

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -331,9 +331,21 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     /**
      * Sends a pause command to GDBBackend, and resolves when the debugger is
      * actually paused. The paused thread ID is saved to `this.waitPausedThreadId`.
-     *
      * @param requireAsync - require gdb to be in async mode to pause
      */
+    protected async pauseIfNeeded(requireAsync?: false): Promise<void>;
+
+    /**
+     * Sends a pause command to GDBBackend, and resolves when the debugger is
+     * actually paused. The paused thread ID is saved to `this.waitPausedThreadId`.
+     *
+     * @param requireAsync - require gdb to be in async mode to pause
+     * @deprecated the `requireAsync` parameter should not be used and will be
+     * removed in the future.
+     * See {@link https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/339#discussion_r1840549671}
+     */
+    protected async pauseIfNeeded(requireAsync: true): Promise<void>;
+
     protected async pauseIfNeeded(requireAsync = false): Promise<void> {
         this.waitPausedNeeded =
             this.isRunning && (!requireAsync || this.gdb.getAsyncMode());

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -331,9 +331,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     /**
      * Sends a pause command to GDBBackend, and resolves when the debugger is
      * actually paused. The paused thread ID is saved to `this.waitPausedThreadId`.
+     *
+     * @param requireAsync - require gdb to be in async mode to pause
      */
-    protected async pauseIfNeeded(): Promise<void> {
-        this.waitPausedNeeded = this.isRunning;
+    protected async pauseIfNeeded(requireAsync = false): Promise<void> {
+        this.waitPausedNeeded =
+            this.isRunning && (!requireAsync || this.gdb.getAsyncMode());
 
         if (this.waitPausedNeeded) {
             const waitPromise = new Promise<void>((resolve) => {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -354,7 +354,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         await waitPromise;
     }
 
-    protected async continue(): Promise<void> {
+    protected async continuePausedThread(): Promise<void> {
         if (this.gdb.isNonStopMode()) {
             await mi.sendExecContinue(this.gdb, this.waitPausedThreadId);
         } else {
@@ -538,7 +538,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         if (this.waitPausedNeeded) {
-            await this.continue();
+            await this.continuePausedThread();
         }
     }
 
@@ -647,7 +647,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         if (this.waitPausedNeeded) {
-            await this.continue();
+            await this.continuePausedThread();
         }
     }
 

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -333,7 +333,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
      * actually paused. The paused thread ID is saved to `this.waitPausedThreadId`.
      */
     protected async pauseIfNeeded(): Promise<void> {
-        this.waitPausedNeeded = this.isRunning && this.gdb.getAsyncMode();
+        this.waitPausedNeeded = this.isRunning;
 
         if (this.waitPausedNeeded) {
             const waitPromise = new Promise<void>((resolve) => {

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -327,7 +327,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         try {
             if (this.targetType === 'remote') {
                 // Need to pause first, then disconnect and exit
-                await this.pauseIfNeeded();
+                await this.pauseIfNeeded(true);
                 await this.gdb.sendCommand('disconnect');
             }
 

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -320,6 +320,10 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         return this.gdbserverProcessManager?.stop();
     }
 
+    /**
+     * WARNING: `disconnectRequest` is unreliable in sync mode.
+     * @see {@link https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/339#discussion_r1840549671}
+     */
     protected async disconnectRequest(
         response: DebugProtocol.DisconnectResponse,
         _args: DebugProtocol.DisconnectArguments

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -326,14 +326,8 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     ): Promise<void> {
         try {
             if (this.targetType === 'remote') {
-                this.waitPausedNeeded =
-                    this.gdb.getAsyncMode() && this.isRunning;
-
-                if (this.waitPausedNeeded) {
-                    // Need to pause first, then disconnect and exit
-                    await this.pause();
-                }
-
+                // Need to pause first, then disconnect and exit
+                await this.pauseIfNeeded();
                 await this.gdb.sendCommand('disconnect');
             }
 

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -326,13 +326,12 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     ): Promise<void> {
         try {
             if (this.targetType === 'remote') {
-                if (this.gdb.getAsyncMode() && this.isRunning) {
-                    // See #295 - this use of "await" is to try to slightly delay the
-                    // call to disconnect. A proper solution that waits for the
-                    // interrupt to be successful is needed to avoid future
-                    // "Cannot execute this command while the target is running"
-                    // errors
-                    await this.gdb.sendCommand('interrupt');
+                this.waitPausedNeeded =
+                    this.gdb.getAsyncMode() && this.isRunning;
+
+                if (this.waitPausedNeeded) {
+                    // Need to pause first, then disconnect and exit
+                    await this.pause();
                 }
 
                 await this.gdb.sendCommand('disconnect');


### PR DESCRIPTION
Closes #295.

Code to suspend/continue the debug session when setting breakpoints are moved to a reusable function `pause` and `continue` methods. The `pause` method `await`s a promise which gets resolves when the target is actually suspended.

This `pause` method is also used in `GDBTargetDebugSession::disconnectRequest`.