### PR TITLE
Array optimisation for variablesRequest

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2008,56 +2008,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     // update the display name for array elements to have square brackets
                     name = `[${child.exp}]`;
                 }
-                if (isArrayParent || isArrayChild) {
-                    // can't use a relative varname (eg. var1.a.b.c) to create/update a new var so fetch and track these
-                    // vars by evaluating their path expression from GDB
-                    const fullPath = await this.getFullPathExpression(
-                        child.name
-                    );
-                    // create or update the var in GDB
-                    let arrobj = this.gdb.varManager.getVar(
-                        frame.frameId,
-                        frame.threadId,
-                        depth,
-                        fullPath
-                    );
-                    if (!arrobj) {
-                        const varCreateResponse = await mi.sendVarCreate(
-                            this.gdb,
-                            {
-                                expression: fullPath,
-                                frameId: frame.frameId,
-                                threadId: frame.threadId,
-                            }
-                        );
-                        arrobj = this.gdb.varManager.addVar(
-                            frame.frameId,
-                            frame.threadId,
-                            depth,
-                            fullPath,
-                            true,
-                            false,
-                            varCreateResponse
-                        );
-                    } else {
-                        arrobj = await this.gdb.varManager.updateVar(
-                            frame.frameId,
-                            frame.threadId,
-                            depth,
-                            arrobj
-                        );
-                    }
-                    // if we have an array parent entry, we need to display the address.
-                    if (isArrayParent) {
-                        value = await this.getAddr(arrobj);
-                    }
-                    arrobj.isChild = true;
-                    varobjName = arrobj.varname;
-                }
                 const variableName = isArrayChild ? name : child.exp;
                 const evaluateName =
                     isArrayParent || isArrayChild
-                        ? await this.getFullPathExpression(child.name)
+                        ? `${topLevelPathExpression}[${child.exp}]`
                         : `${topLevelPathExpression}.${child.exp}`;
                 variables.push({
                     name: variableName,


### PR DESCRIPTION
Hi @jonahgraham ,

As we discussed the issue previously, this is an update to optimising the array read operation in the `variablesRequest`. 

Recently, there are some redundant operations performed during the `variablesRequest` in the adapter, causing a performance issue while retreiving larger arrays. The operation, which is removed in this update, creates O(n) compexity in the read operation in terms of gdb communication. With this update, by removing this redundant logic, gdb communication complexity is going to decrease to O(1). 

Update tested manually in 1-dimensional int array, 2-dimensional int array, 1 dimensional struct array and 1-dimensional struct contains 1-dimensional array element. We observe the increase in the performance without having issue on the read operation. 

Could you please review this update when you are suitable?

**PS:** Besides the removal of the array logic, the `this.getFullPathExpression` is also replaced since still causing an expensive gdb request which affects the performance.