### PR TITLE
Add supportsEvaluateForHovers

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -205,6 +205,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             os.platform() === 'linux' && this.supportsRunInTerminalRequest;
         response.body = response.body || {};
         response.body.supportsConfigurationDoneRequest = true;
+        response.body.supportsEvaluateForHovers = true;
         response.body.supportsSetVariable = true;
         response.body.supportsConditionalBreakpoints = true;
         response.body.supportsHitConditionalBreakpoints = true;


### PR DESCRIPTION
There is a slight concern of turning this on for GDB as it is documented with this [requirement](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Capabilities):

> The debug adapter supports a (side effect free) `evaluate`
> request for data hovers.

Because of side-effects on read that is present in memory mapped registers in embedded systems this can cause unexpected reads of the target's registers.  For Eclipse CDT I don't think there is any special code, so I think it is ok to do this here too. GDB also has a number of settings that may be useful to prevent accidental reads too.

Fixes https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/121