### PR TITLE
Disassembly address handling improvement

### DIFF
--- a/src/util/calculateMemoryOffset.ts
+++ b/src/util/calculateMemoryOffset.ts
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 
+import { isHexString } from './isHexString';
+
 /**
  * This method calculates the memory offset arithmetics on string hexadecimal address value
  *
@@ -22,9 +24,12 @@ export const calculateMemoryOffset = (
     address: string,
     offset: string | number | bigint
 ): string => {
-    if (address.startsWith('0x')) {
+    if (isHexString(address)) {
         const addressLength = address.length - 2;
         const newAddress = BigInt(address) + BigInt(offset);
+        if (newAddress < 0) {
+            return `(0x${'0'.padStart(addressLength, '0')})${newAddress}`;
+        }
         return `0x${newAddress.toString(16).padStart(addressLength, '0')}`;
     } else {
         const addrParts = /^([^+-]*)([+-]\d+)?$/g.exec(address);

--- a/src/util/isHexString.ts
+++ b/src/util/isHexString.ts
@@ -1,0 +1,20 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+/**
+ * Checks if the given value is an hex string starting with 0x
+ *
+ * @param value
+ * 		Reference value to check. For example '0x0000FF00', 'main', 'main+200'
+ * @return
+ * 		Returns true if value is an hex string, otherwise returns false.
+ */
+
+export const isHexString = (value: string) => /^0x[\da-f]+$/i.test(value);


### PR DESCRIPTION
Hi @jonahgraham ,

We observe some issues in while using the disassembly in embedded devices due to sending disassemble request for negative memory regions. We implemented a code-update to limit the lower bound of the query to the address 0x0. 

If we still need to fill more instructions depending on the DAP request, you may realise that we used relative addresses in the empty instructions (e.g. (0x00)-2, (0x00)-4 etc). This is arguable and I am happy to hear your thoughts. Simply the VSCode is ignoring these lines and not showing in the disassembly window (maybe because they are not convertable to number or bigint).

It was hard to check this behaviour in unit test, thus I implemented a test for the internal function and checked the behaviour over that internal function. 

Could you please review the update when you are suitable? I am happy to hear your feedback.

Kind regards

Asim