### PR TITLE
Hardware/Software Breakpoint Modes (Breakpoint Types)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/utf8": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
-    "@vscode/debugadapter-testsupport": "^1.59.0",
+    "@vscode/debugadapter-testsupport": "^1.68.0",
     "browserify": "^17.0.0",
     "chai": "^4.3.7",
     "chai-string": "^1.5.0",

--- a/src/integration-tests/breakpointModes.spec.ts
+++ b/src/integration-tests/breakpointModes.spec.ts
@@ -1,0 +1,272 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import * as path from 'path';
+import * as os from 'os';
+import { expect } from 'chai';
+import { CdtDebugClient } from './debugClient';
+import { standardBeforeEach, testProgramsDir, fillDefaults } from './utils';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { MIBreakpointMode } from '../mi';
+
+// This mock adapter is overriding the getBreakpointOptions method.
+const adapter =
+    'integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.js';
+const argHardwareBreakpointTrue = '--hardware-breakpoint-true';
+const argHardwareBreakpointFalse = '--hardware-breakpoint-false';
+const argBreakpointModeHardware = ['--breakpoint-mode', 'hardware'];
+const argBreakpointModeSoftware = ['--breakpoint-mode', 'software'];
+
+const program = 'count';
+
+const startDebugClientWithArgs = async (
+    test: Mocha.Test | undefined,
+    ...args: string[]
+) => {
+    const dc = await standardBeforeEach(adapter, args);
+    await dc.launchRequest(
+        fillDefaults(test, {
+            program: path.join(testProgramsDir, 'count'),
+        })
+    );
+    return dc;
+};
+
+const sendBreakpointRequest = (
+    dc: CdtDebugClient,
+    options?: Partial<DebugProtocol.SourceBreakpoint>
+) => {
+    return dc.setBreakpointsRequest({
+        source: {
+            name: `${program}.c`,
+            path: path.join(testProgramsDir, `${program}.c`),
+        },
+        breakpoints: [
+            {
+                column: 1,
+                line: 4,
+                ...(options ?? {}),
+            },
+        ],
+    });
+};
+
+const expectBreakpoint = async (
+    dc: CdtDebugClient,
+    response: DebugProtocol.SetBreakpointsResponse,
+    breakpointMode: MIBreakpointMode
+) => {
+    expect(response.body.breakpoints.length).eq(1);
+    expect(response.body.breakpoints[0].verified).eq(true);
+    expect(response.body.breakpoints[0].message).eq(undefined);
+    await dc.configurationDoneRequest();
+
+    let isCorrect;
+    let outputs;
+    while (!isCorrect) {
+        // Cover the case of getting event in Linux environment.
+        // If cannot get correct event, program timeout and test case failed.
+        outputs = await dc.waitForEvent('output');
+        isCorrect = outputs.body.output.includes('breakpoint-modified');
+    }
+    expect(outputs?.body.output).includes(
+        `type="${
+            breakpointMode === 'hardware' ? 'hw breakpoint' : 'breakpoint'
+        }"`
+    );
+    const stoppedOutput = await dc.waitForEvent('stopped');
+    expect(stoppedOutput.body?.reason).eq('breakpoint');
+};
+
+// Hardware breakpoint tests are not working, so skipped for Windows.
+// For further information, please check the discussion here:
+// https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/350
+const skipHardwareBreakpointTest = os.platform() === 'win32';
+
+describe('breakpoint mode', async () => {
+    let dc: CdtDebugClient;
+
+    afterEach(async () => {
+        await dc.stop();
+    });
+
+    describe('with no override', async () => {
+        beforeEach(async function () {
+            dc = await startDebugClientWithArgs(this.currentTest);
+        });
+
+        it('insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'hardware',
+            });
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'software',
+            });
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+    });
+
+    describe('with options hardware is true', async () => {
+        beforeEach(async function () {
+            dc = await startDebugClientWithArgs(
+                this.currentTest,
+                argHardwareBreakpointTrue
+            );
+        });
+
+        it('when no mode - insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc);
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('when mode is hardware - insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'hardware',
+            });
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('when mode is software - insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'software',
+            });
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+    });
+
+    describe('with options hardware is false', async () => {
+        beforeEach(async function () {
+            dc = await startDebugClientWithArgs(
+                this.currentTest,
+                argHardwareBreakpointFalse
+            );
+        });
+
+        it('when no mode - insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc);
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+
+        it('when mode is hardware - insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'hardware',
+            });
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('when mode is software - insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'software',
+            });
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+    });
+
+    describe('with options mode overriden to hardware', async () => {
+        beforeEach(async function () {
+            dc = await startDebugClientWithArgs(
+                this.currentTest,
+                ...argBreakpointModeHardware
+            );
+        });
+
+        it('with no mode in request - insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc);
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('with mode is hardware in request - insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'hardware',
+            });
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+
+        it('with mode is software in request - still insert breakpoint as hardware breakpoint', async function () {
+            if (skipHardwareBreakpointTest) {
+                this.skip();
+            }
+
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'software',
+            });
+
+            await expectBreakpoint(dc, response, 'hardware');
+        });
+    });
+
+    describe('with options mode overriden to software', async () => {
+        beforeEach(async function () {
+            dc = await startDebugClientWithArgs(
+                this.currentTest,
+                ...argBreakpointModeSoftware
+            );
+        });
+
+        it('with no mode in request - insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc);
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+
+        it('with mode is hardware in request - still insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'hardware',
+            });
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+
+        it('with mode is software in request - insert breakpoint as software breakpoint', async function () {
+            const response = await sendBreakpointRequest(dc, {
+                mode: 'software',
+            });
+
+            await expectBreakpoint(dc, response, 'software');
+        });
+    });
+});

--- a/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
+++ b/src/integration-tests/mocks/debugAdapters/dynamicBreakpointOptions.ts
@@ -11,7 +11,11 @@
 import { logger } from '@vscode/debugadapter/lib/logger';
 import { GDBBackend } from '../../../gdb/GDBBackend';
 import { GDBTargetDebugSession } from '../../../desktop/GDBTargetDebugSession';
-import { MIBreakpointLocation, MIBreakpointInsertOptions } from '../../../mi';
+import {
+    MIBreakpointLocation,
+    MIBreakpointInsertOptions,
+    MIBreakpointMode,
+} from '../../../mi';
 import { GDBFileSystemProcessManager } from '../../../desktop/processManagers/GDBFileSystemProcessManager';
 import {
     AttachRequestArguments,
@@ -35,6 +39,16 @@ const hardwareBreakpointTrue = process.argv.includes(
 const hardwareBreakpointFalse = process.argv.includes(
     '--hardware-breakpoint-false'
 );
+
+// Breakpoint mode to override
+const breakpointModeIndex = process.argv.indexOf('--breakpoint-mode');
+const breakpointMode =
+    breakpointModeIndex < 0
+        ? undefined
+        : (process.argv[breakpointModeIndex + 1] as
+              | MIBreakpointMode
+              | undefined);
+
 const throwError = process.argv.includes('--throw-error');
 
 class DynamicBreakpointOptionsGDBBackend extends GDBBackend {
@@ -52,7 +66,8 @@ class DynamicBreakpointOptionsGDBBackend extends GDBBackend {
             : hardwareBreakpointFalse
             ? false
             : initialOptions.hardware;
-        return { ...initialOptions, hardware };
+        const mode = breakpointMode ?? initialOptions.mode;
+        return { ...initialOptions, mode, hardware };
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,12 +783,12 @@
     "@typescript-eslint/types" "5.54.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vscode/debugadapter-testsupport@^1.59.0":
-  version "1.59.0"
-  resolved "https://registry.yarnpkg.com/@vscode/debugadapter-testsupport/-/debugadapter-testsupport-1.59.0.tgz#d29b89f6285424435499e9bb5ad42e5db01f3a11"
-  integrity sha512-Q25IHmZCTHispSg/h3kBa8M2EGPFgZGbwt3hlGA53ydWlF0TUEJ12oW9ODMEBO+VAk+GGrHW/C6iCLgyLvcPPw==
+"@vscode/debugadapter-testsupport@^1.68.0":
+  version "1.68.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugadapter-testsupport/-/debugadapter-testsupport-1.68.0.tgz#27e7c38d2f5af1e1c4f9ca88b87bccf5c4cefab2"
+  integrity sha512-UpbaPsCGMKyjIvJFtqFKDD1MVvME50xuOtRBPrqY1WdhAOLjWQN7FcKEoHv3X85twfNL21jW2M54FYwEdEQv4Q==
   dependencies:
-    "@vscode/debugprotocol" "1.59.0"
+    "@vscode/debugprotocol" "1.68.0"
 
 "@vscode/debugadapter@^1.68.0":
   version "1.68.0"
@@ -796,11 +796,6 @@
   integrity sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==
   dependencies:
     "@vscode/debugprotocol" "1.68.0"
-
-"@vscode/debugprotocol@1.59.0":
-  version "1.59.0"
-  resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.59.0.tgz#f173ff725f60e4ff1002f089105634900c88bd77"
-  integrity sha512-Ks8NiZrCvybf9ebGLP8OUZQbEMIJYC8X0Ds54Q/szpT/SYEDjTksPvZlcWGTo7B9t5abjvbd0jkNH3blYaSuVw==
 
 "@vscode/debugprotocol@1.68.0", "@vscode/debugprotocol@^1.68.0":
   version "1.68.0"


### PR DESCRIPTION
Hi @jonahgraham ,

We like to send an update for new DAP feature "Breakpoint Modes". Here in this update I added hardware and software breakpoint types where the debug adapter sends this capability to the IDE, and uses this information during the breakpoint operations.

I would appreciate it if you can check the pull request when you are suitable. 

By the way, there could be some arguable decisions here, let me emphasis the important points:

1. Enabling the breakpointModes as Hardware and Software:

I implemented the idea over 'hardware' and 'software' modes. By default, I enabled both of the modes, however I implemented a separate function `getBreakpointModes` to let user to override the function if they needed. Thus, user can override the behaviour and return any desired combination.

In this new implementation, I priotize the `mode` information over `hardware` flag, in other words, if `mode` is defined I considered the `mode` parameter, otherwise I checked the `hardware` flag.

2. `hardware` flag became redundant after having the `mode` property:

Previously we have a `hardware` flag on `MIBreakpointInsertOptions` class, this flag became redundant after the having the `mode` property. I still left the `hardware` flag for backward compatibility. Moreover, the `hardware` controlled by launch arguments to force debug adapter to send the breakpoints as hardware breakpoints. Maybe we can consider to introduce a `defaultBreakpointMode` parameter and remove the `hardwareBreakpoint` parameter. I didnot make a change to avoid breaking the current users.

3. Windows tests:

I couldn't managed to run the hardware breakpoint tests in the Windows, conditions like isRemoteTest or !isRemoteTest seems failing too, please let me know, if there is a better Windows test conditions.

Kind regards,

Asim
