### PR TITLE
Suppressing unneeded error message when hovering

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1278,10 +1278,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
             } else {
                 this.sendErrorResponse(
-                        response,
-                        1,
-                        err instanceof Error ? err.message : String(err)
-                    );
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
             }
         }
     }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1274,7 +1274,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         } catch (err) {
             if (err instanceof Error) {
                 if (err.message === '-var-create: unable to create variable object') {
-                    return;
+                    this.sendResponse(response);
                 }
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1272,11 +1272,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(
-                response,
-                1,
-                err instanceof Error ? err.message : String(err)
-            );
+            if (err instanceof Error) {
+                if (err.message === '-var-create: unable to create variable object') {
+                    return;
+                }
+            } else {
+                this.sendErrorResponse(
+                        response,
+                        1,
+                        err instanceof Error ? err.message : String(err)
+                    );
+            }
         }
     }
 

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1272,10 +1272,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            if (err instanceof Error) {
-                if (err.message === '-var-create: unable to create variable object') {
-                    this.sendResponse(response);
-                }
+            if (err instanceof Error && err.message === '-var-create: unable to create variable object') {
+                this.sendResponse(response);
             } else {
                 this.sendErrorResponse(
                     response,

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1272,7 +1272,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            if (err instanceof Error && err.message === '-var-create: unable to create variable object') {
+            if (
+                err instanceof Error &&
+                err.message === '-var-create: unable to create variable object'
+            ) {
                 this.sendResponse(response);
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1276,6 +1276,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 err instanceof Error &&
                 err.message === '-var-create: unable to create variable object'
             ) {
+                if (args.context === 'hover') {
+                    response.success = false;
+                }
                 this.sendResponse(response);
             } else {
                 this.sendErrorResponse(

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -68,7 +68,7 @@ describe('evaluate request', function () {
         );
     });
 
-    it('should reject evaluation of invalid expression', async function () {
+    it('should send an error when evaluating an invalid expression', async function () {
         const err = await dc.evaluateRequest({
             context: 'repl',
             expression: '2 +',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -69,15 +69,13 @@ describe('evaluate request', function () {
     });
 
     it('should reject evaluation of invalid expression', async function () {
-        const err = await expectRejection(
-            dc.evaluateRequest({
-                context: 'repl',
-                expression: '2 +',
-                frameId: scope.frame.id,
-            })
-        );
+        const err = await dc.evaluateRequest({
+            context: 'repl',
+            expression: '2 +',
+            frameId: scope.frame.id,
+        });
 
-        expect(err.message).eq('-var-create: unable to create variable object');
+        expect(err.body.result).eq('Error: could not evaluate expression');
     });
     it('should be able to update the value of a variable named monitor and that variable has local scope', async function () {
         const res1 = await dc.evaluateRequest({


### PR DESCRIPTION
Previous behaviour:

when hovering over non variables, i.e. comments or keywords (for, while, etc.), an error message appeared "-var-create: unable to create variable object". Although this is technically a correct behaviour, it was frustrating to users to see an error message just because they are hovering over comment sections in their code.

Current behaviour:

This error message is now suppressed when hovering over comments. 