### PR TITLE
Add breakpoint from the debug console support

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -467,7 +467,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     // Create a boolean variable to check if the breakpoint is in the right location
                     let isBreakpointInRightLocation = false;
                     // Check if the gdb breakpoint is in the same file being checked now
-                    const isSameFileName = gdbbp['original-location']?.includes(file)? true : false;
+                    const isSameFileName = gdbbp['original-location']?.includes(file) ? true : false;
                     // Create a regex for gdb-mi original-location format (--source <file-name> --line <line-number>)
                     const regexMi = new RegExp('^-source.+-line\\s+([0-9]+)$');
                     // Create a regex for gdb-mi original-location format (<file-name>:<line-number>)

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -468,7 +468,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     let isBreakpointInRightLocation = false;
                     // Check if the gdb breakpoint is in the same file being checked now
                     const isSameFileName = gdbbp['original-location']?.includes(file) ? true : false;
-                    // Create a regex for gdb-mi original-location format (--source <file-name> --line <line-number>)
+                    // Create a regex for gdb-mi original-location format (-source <file-name> -line <line-number>)
                     const regexMi = new RegExp('^-source.+-line\\s+([0-9]+)$');
                     // Create a regex for gdb-mi original-location format (<file-name>:<line-number>)
                     const regexWithoutMi = new RegExp('^.*:([0-9]+)$');
@@ -1729,13 +1729,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 break;
             }
             case 'thread-selected':
-                break;
             case 'thread-group-added':
-                break;
             case 'thread-group-started':
-                break;
             case 'thread-group-exited':
-                break;
             case 'library-loaded':
                 break;
             case 'breakpoint-created':
@@ -1746,7 +1742,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     const breakpoint : DebugProtocol.Breakpoint = {
                         id: parseInt(notifyData.bkpt.number, 10),
                         verified: notifyData.bkpt.enabled === 'y',
-                        //verified: false,
                         source: {
                             name: notifyData.bkpt.fullname,
                             path: notifyData.bkpt.file,
@@ -1755,7 +1750,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('new', breakpoint);
                     this.sendEvent(breakpointevent);
-                    this.sendEvent(new Event("UpdateBreakpointView", {}));
+                    this.sendEvent(new Event("cdt-gdb-adapter/UpdateBreakpointView", {}));
                 }
                 break;
             case 'breakpoint-modified':
@@ -1771,7 +1766,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('changed', breakpoint);
                     this.sendEvent(breakpointevent);
-                    this.sendEvent(new Event("UpdateBreakpointView", {}));
+                    this.sendEvent(new Event("cdt-gdb-adapter/UpdateBreakpointView", {}));
                 }
                 break;
             case 'breakpoint-deleted':
@@ -1782,7 +1777,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('removed', breakpoint);
                     this.sendEvent(breakpointevent);
-                    this.sendEvent(new Event("UpdateBreakpointView", {}));
+                    this.sendEvent(new Event("cdt-gdb-adapter/UpdateBreakpointView", {}));
                 }
                 break;
             case 'cmd-param-changed':

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -463,24 +463,20 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         gdbbp.type === 'hw breakpoint';
 
                     // Check with original-location so that relocated breakpoints are properly matched
-                    let isBreakpointInRightLocation : boolean = false;
-                    const isSameFileName = gdbbp['original-location']?.includes(file);
-                    // Create a regex for gdb-mi original-location format
+                    // Create a boolean variable to check if the breakpoint is in the right location
+                    let isBreakpointInRightLocation = false;
+                    // Check if the gdb breakpoint is in the same file being checked now
+                    const isSameFileName = gdbbp['original-location']?.includes(file)? true : false;
+                    // Create a regex for gdb-mi original-location format (--source <file-name> --line <line-number>)
                     const regexMi = new RegExp('^-source.+-line\\s+([0-9]+)$');
-                    let regexmatch = gdbbp['original-location']?.match(regexMi);
-                    if(!regexmatch) {
-                        // if no match with the gdb-mi format, check normal gdb format
-                        const regexWithoutMi = new RegExp('^.*:([0-9]+)$');
-                        regexmatch = gdbbp['original-location']?.match(regexWithoutMi);
-                        if(regexmatch) {
-                            // if there is still no match, leave isBreakpointInRightLocation as false
-                            isSameFileName && (+regexmatch[1] == vsbp.line) ? isBreakpointInRightLocation = true : false;
-                        }
-                    } else {
-                        isSameFileName && (+regexmatch[1] == vsbp.line) ? isBreakpointInRightLocation = true : false;
+                    // Create a regex for gdb-mi original-location format (<file-name>:<line-number>)
+                    const regexWithoutMi = new RegExp('^.*:([0-9]+)$');
+                    // Check if gdbbp original-location matches regexMI
+                    const regexMatch = gdbbp['original-location']?.match(regexMi)??gdbbp['original-location']?.match(regexWithoutMi);
+                    if(regexMatch && isSameFileName) {
+                        isBreakpointInRightLocation = (isSameFileName && (regexMatch[1] === String(vsbp.line)));
                     }
-                    //const gdbOriginalLocation = `${gdbOriginalLocationPrefix}${vsbp.line}`;
-                    //gdbbp['original-location'] === gdbOriginalLocation
+                                        
                     return !!(
                         isBreakpointInRightLocation &&
                         vsbpCond === gdbbpCond &&

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import * as mi from '../mi';
 import {
     BreakpointEvent,
+    Event,
     Handles,
     InitializedEvent,
     Logger,
@@ -1754,6 +1755,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('new', breakpoint);
                     this.sendEvent(breakpointevent);
+                    this.sendEvent(new Event("UpdateBreakpointView", {}));
                 }
                 break;
             case 'breakpoint-modified':
@@ -1769,6 +1771,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('changed', breakpoint);
                     this.sendEvent(breakpointevent);
+                    this.sendEvent(new Event("UpdateBreakpointView", {}));
                 }
                 break;
             case 'breakpoint-deleted':
@@ -1779,6 +1782,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     };
                     const breakpointevent =  new BreakpointEvent('removed', breakpoint);
                     this.sendEvent(breakpointevent);
+                    this.sendEvent(new Event("UpdateBreakpointView", {}));
                 }
                 break;
             case 'cmd-param-changed':

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -474,7 +474,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     const regexWithoutMi = new RegExp('^.*:([0-9]+)$');
                     // Check if gdbbp original-location matches regexMI
                     const regexMatch = gdbbp['original-location']?.match(regexMi)??gdbbp['original-location']?.match(regexWithoutMi);
-                    if(regexMatch && isSameFileName) {
+                    if (regexMatch && isSameFileName) {
                         isBreakpointInRightLocation = (isSameFileName && (regexMatch[1] === String(vsbp.line)));
                     }
                                         


### PR DESCRIPTION
Previous behaviour:

Users were able to add breakpoints from the GUI of vscode itself. However, if a user set a breakpoint from the debug console, the breakpoint would not get reflected on the GUI with a red dot, even though the breakpoint was set by GDB in the backend.

Changes:

Users can now set breakpoints from the debug console and the behaviour will be reflected on the GUI. The GDB breakpoint notifications (breakpoint-created, breakpoint-modified, breakpoint-deleted) are now handled on the adapter's side.

Problems:
VScode has a bug in which standard Breakpoint events do not trigger a re-rendering of the breakpoint GUI. Breakpoints are visible in the breakpoints list on the side panel, but red dots are not visible on the source code. Therefore, I created a custom event that would trigger a re-rendering for vscode, so that red dots can appear on the source file
VScode 