### PR TITLE
Add docker image for testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+# Use a base image
+FROM node:20
+
+# Create app directory
+WORKDIR /work
+
+# Install GCC
+RUN apt-get update
+RUN apt-get -y install build-essential gcc g++ gdb gdbserver socat
+RUN gdb --version
+RUN gcc --version
+RUN gdbserver --version
+#RUN sysctl kernel.yama.ptrace_scope=0
+
+# Copy your app's source code
+#COPY . .
+
+## Build the project
+#RUN yarn
+#
+## Build test programs
+#RUN make -C src/integration-tests/test-programs
+#
+## Run tests
+#RUN yarn test:integration
+#
+## Expose a port
+#EXPOSE 3000
+
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "node",
+    "build": { "dockerfile": "Dockerfile" },
+  
+    "customizations": {
+      "vscode": {
+        "extensions": []
+      }
+    }
+}


### PR DESCRIPTION
Added a docker image and a devcontainer.json for a better testing experience on various machines.

Previous behaviour:
Running the integration tests seemed to be rather challenging on Mac, mainly for two reasons:
1. gdb on mac is not solid
2. the docker container provided in the readme uses an old version of gdb and gcc

Current behaviour:
I created a docker image that installs latest gcc and gdb. Also a devcontainer.json is created for a seamless experience of debugging the tests on vscode and opening the whole project inside of docker via vscode