### PR TITLE
Fix tests to handle GDB16+ new handling of breakpoint relocations

### DIFF
--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -264,12 +264,12 @@ describe('breakpoints', async function () {
             breakpoints: [
                 {
                     column: 1,
-                    line: 5,
+                    line: 6,
                 },
             ],
         });
         expect(bpResp1.body.breakpoints.length).to.eq(1);
-        expect(bpResp1.body.breakpoints[0].line).eq(5);
+        expect(bpResp1.body.breakpoints[0].line).eq(6);
         const bpResp2 = await dc.setBreakpointsRequest({
             source: {
                 name: 'count space.c',
@@ -282,14 +282,14 @@ describe('breakpoints', async function () {
                 },
                 {
                     column: 1,
-                    line: 5,
+                    line: 6,
                 },
             ],
         });
         expect(bpResp2.body.breakpoints.length).to.eq(2);
         expect(bpResp2.body.breakpoints[0].line).eq(2);
-        expect(bpResp2.body.breakpoints[1].line).eq(5);
-        // Make sure the GDB id of the breakpoint on line 5 is unchanged
+        expect(bpResp2.body.breakpoints[1].line).eq(6);
+        // Make sure the GDB id of the breakpoint on line 6 is unchanged
         expect(bpResp2.body.breakpoints[1].id).eq(
             bpResp1.body.breakpoints[0].id
         );
@@ -359,16 +359,16 @@ describe('breakpoints', async function () {
             breakpoints: [
                 {
                     column: 1,
-                    line: 7, // this will be relocated to line 9 as no code on line 7
+                    line: 5, // this will be relocated to line 6 as no code on line 5
                 },
             ],
         } as DebugProtocol.SetBreakpointsArguments;
         const bpResp1 = await dc.setBreakpointsRequest(args);
         expect(bpResp1.body.breakpoints.length).to.eq(1);
-        expect(bpResp1.body.breakpoints[0].line).eq(9);
+        expect(bpResp1.body.breakpoints[0].line).eq(6);
         const bpResp2 = await dc.setBreakpointsRequest(args);
         expect(bpResp2.body.breakpoints.length).to.eq(1);
-        expect(bpResp2.body.breakpoints[0].line).eq(9);
+        expect(bpResp2.body.breakpoints[0].line).eq(6);
         // Make sure the GDB id of the breakpoint is unchanged
         expect(bpResp2.body.breakpoints[0].id).eq(
             bpResp1.body.breakpoints[0].id

--- a/src/integration-tests/test-programs/count space.c
+++ b/src/integration-tests/test-programs/count space.c
@@ -2,6 +2,7 @@ static int staticfunc1(void) {
     return 2;
 }
 static int staticfunc2(void) {
+    // line with no code
     return 2;
 }
 


### PR DESCRIPTION
GDB 16 includes https://github.com/bminor/binutils-gdb/commit/dcaa85e58c4ef50a92908e071ded631ce48c971c which is "gdb: reject inserting breakpoints between functions"

The modified tests were unintentionally inserting breakpoints on blank lines that were between functions that is no longer supported.

Partial fix for #369, specifically the part in
https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/369#issuecomment-2880408787