### PR TITLE
v1.0.8-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-adapter",
-  "version": "1.0.7-next",
+  "version": "1.0.8-next",
   "description": "gdb adapter implementing the debug adapter protocol",
   "main": "dist/index.js",
   "browser": "dist/browser/web.js",


### PR DESCRIPTION
While writing up instructions on how to publish the package, I accidentally published 1.0.7. I immediately unpublished it, but this commit bumps the "next" to the appropriate value.