### PR TITLE
Setting a warning for enable/disable breakpoint commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Refactor [#362](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/362): Cannot execute CLI commands like > interrupt from Debug Console while CPU is running
+-   Feature Request [#385](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/385): Setting a warning for enable/disable breakpoint commands
 
 ## 1.0.9
 

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1267,7 +1267,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 ) {
                     this.sendEvent(
                         new OutputEvent(
-                            'warning: "enable" and "disable" commands cannot be reflected in the GUI', 'stdout'
+                            'warning: "enable" and "disable" commands cannot be reflected in the GUI',
+                            'stdout'
                         )
                     );
                 }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1262,12 +1262,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     '^\\s*enable\\s*(?:breakpoint|count|delete|once)?\\d*'
                 );
                 if (
-                    args.expression.slice(1, -1).search(regexDisable) != -1 ||
-                    args.expression.slice(1, -1).search(regexEnable) != -1
+                    args.expression.slice(1).search(regexDisable) != -1 ||
+                    args.expression.slice(1).search(regexEnable) != -1
                 ) {
                     this.sendEvent(
                         new OutputEvent(
-                            'warning: "enable" and "disable" commands cannot be reflected in the GUI'
+                            'warning: "enable" and "disable" commands cannot be reflected in the GUI', 'stdout'
                         )
                     );
                 }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 import * as mi from '../mi';
 import {
     BreakpointEvent,
-    Event,
     Handles,
     InitializedEvent,
     Logger,
@@ -1256,6 +1255,18 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             }
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
+                const regexDisable = new RegExp('.*disable.*');
+                const regexEnable = new RegExp('.*enable.*');
+                if (
+                    args.expression.slice(1, -1).search(regexDisable) ||
+                    args.expression.slice(1, -1).search(regexEnable)
+                ) {
+                    this.sendEvent(
+                        new OutputEvent(
+                            'warning: enable and disable commands cannot be reflected in the GUI'
+                        )
+                    );
+                }
                 return await this.evaluateRequestGdbCommand(
                     response,
                     args,
@@ -1781,16 +1792,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 );
         }
     }
-    /* 
-    A function that sends a custom event to vscode extension. The Custom event being sent triggers a re-rendering of breakpoints on the GUI of vscode, as it seems rendering breakpoints is glitchy on vscode
-    */
-    private sendUpdateBreakpointView(message: string) {
-        this.sendEvent(
-            new Event('cdt-gdb-adapter/UpdateBreakpointView', {
-                message: message,
-            })
-        );
-    }
 
     protected handleGDBNotify(notifyClass: string, notifyData: any) {
         switch (notifyClass) {
@@ -1811,6 +1812,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 break;
             case 'breakpoint-created':
                 {
+                    // Check if the bp is going to be erased in the future, if so, don't send the bp event
                     if (notifyData.bkpt.disp === 'del') {
                         break;
                     }
@@ -1828,14 +1830,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         breakpoint
                     );
                     this.sendEvent(breakpointevent);
-                    this.sendUpdateBreakpointView('Breakpoint-created');
                 }
                 break;
             case 'breakpoint-modified':
                 {
+                    // Check if the bp is going to be erased in the future, if so, don't send the bp event
+                    if (notifyData.bkpt.disp === 'del') {
+                        break;
+                    }
                     const breakpoint: DebugProtocol.Breakpoint = {
                         id: parseInt(notifyData.bkpt.number, 10),
-                        verified: notifyData.bkpt.enabled === 'y',
+                        verified: true,
                         source: {
                             name: notifyData.bkpt.fullname,
                             path: notifyData.bkpt.file,
@@ -1847,7 +1852,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         breakpoint
                     );
                     this.sendEvent(breakpointevent);
-                    this.sendUpdateBreakpointView('Breakpoint-modified');
                 }
                 break;
             case 'breakpoint-deleted':
@@ -1861,7 +1865,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         breakpoint
                     );
                     this.sendEvent(breakpointevent);
-                    this.sendUpdateBreakpointView('Breakpoint-deleted');
                 }
                 break;
             case 'cmd-param-changed':

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1255,11 +1255,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             }
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
-                const regexDisable = new RegExp('\s*disable\s*');
-                const regexEnable = new RegExp('\s*enable\s*');
+                const regexDisable = new RegExp('\\s*disable\\s*');
+                const regexEnable = new RegExp('\\s*enable\\s*');
                 if (
-                    args.expression.slice(1, -1).search(regexDisable) ||
-                    args.expression.slice(1, -1).search(regexEnable)
+                    args.expression.slice(1, -1).search(regexDisable) != -1 ||
+                    args.expression.slice(1, -1).search(regexEnable) != -1
                 ) {
                     this.sendEvent(
                         new OutputEvent(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1256,10 +1256,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
                 const regexDisable = new RegExp(
-                    '^\\s*disable\\s*(?:breakpoint|count|delete|once)?\\d*'
+                    '^\\s*disable\\s*(?:(?:breakpoint|count|delete|once)\\d*)?\\s*\\d*\\s*$'
                 );
                 const regexEnable = new RegExp(
-                    '^\\s*enable\\s*(?:breakpoint|count|delete|once)?\\d*'
+                    '^\\s*enable\\s*(?:(?:breakpoint|count|delete|once)\\d*)?\\s*\\d*\\s*$'
                 );
                 if (
                     args.expression.slice(1).search(regexDisable) != -1 ||

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1256,10 +1256,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
                 const regexDisable = new RegExp(
-                    '^\\s*disable\\s*(?:(?:breakpoint)|(?:count)|(?:delete)|(?:once)|)\\d*'
+                    '^\\s*disable\\s*(?:breakpoint|count|delete|once)?\\d*'
                 );
                 const regexEnable = new RegExp(
-                    '^\\s*enable\\s*(?:(?:breakpoint)|(?:count)|(?:delete)|(?:once)|)\\d*'
+                    '^\\s*enable\\s*(?:breakpoint|count|delete|once)?\\d*'
                 );
                 if (
                     args.expression.slice(1, -1).search(regexDisable) != -1 ||

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1255,8 +1255,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             }
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
-                const regexDisable = new RegExp('\\s*disable\\s*');
-                const regexEnable = new RegExp('\\s*enable\\s*');
+                const regexDisable = new RegExp(
+                    '^\\s*disable\\s*(?:(?:breakpoint)|(?:count)|(?:delete)|(?:once)|)\\d*'
+                );
+                const regexEnable = new RegExp(
+                    '^\\s*enable\\s*(?:(?:breakpoint)|(?:count)|(?:delete)|(?:once)|)\\d*'
+                );
                 if (
                     args.expression.slice(1, -1).search(regexDisable) != -1 ||
                     args.expression.slice(1, -1).search(regexEnable) != -1

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1255,15 +1255,15 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             }
 
             if (args.expression.startsWith('>') && args.context === 'repl') {
-                const regexDisable = new RegExp('.*disable.*');
-                const regexEnable = new RegExp('.*enable.*');
+                const regexDisable = new RegExp('\s*disable\s*');
+                const regexEnable = new RegExp('\s*enable\s*');
                 if (
                     args.expression.slice(1, -1).search(regexDisable) ||
                     args.expression.slice(1, -1).search(regexEnable)
                 ) {
                     this.sendEvent(
                         new OutputEvent(
-                            'warning: enable and disable commands cannot be reflected in the GUI'
+                            'warning: "enable" and "disable" commands cannot be reflected in the GUI'
                         )
                     );
                 }

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -50,10 +50,10 @@ describe('breakpoints', async function () {
         /* 
             Create an event variable that will eventually wait for the custom event being sent when a breakpoint is created
             Just using 
-            await dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView'); 
+            await dc.waitForEvent('breakpoint'); 
             is NOT enough, as it misses the event from the adapter due to misalignment issues
         */
-        const event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        const event = dc.waitForEvent('breakpoint');
         // Trigger a breakpoint from the debug-console/Terminal
         await dc.evaluateRequest({
             expression: `>break ${testProgramsDir}/count.c:4`,
@@ -64,7 +64,8 @@ describe('breakpoints', async function () {
         // Run a configuration Done Request to inform the adapter that the client is done
         await dc.configurationDoneRequest();
 
-        expect(outputs.body.message).eq('Breakpoint-created');
+        expect(outputs.body.reason).eq('new');
+        expect(outputs.body.breakpoint.line).eq(4);
     });
 
     it('should handle a breakpoint modification from the debug-console/terminal', async function () {
@@ -76,10 +77,10 @@ describe('breakpoints', async function () {
         /* 
             Create an event variable that will eventually wait for the custom event being sent when a breakpoint is created
             Just using 
-            await dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView'); 
+            await dc.waitForEvent('breakpoint'); 
             is NOT enough, as it misses the event from the adapter due to misalignment issues
         */
-        event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        event = dc.waitForEvent('breakpoint');
         // Create a breakpoint from the debug-console/Terminal
         await dc.evaluateRequest({
             expression: `>break ${testProgramsDir}/count.c:4`,
@@ -89,7 +90,7 @@ describe('breakpoints', async function () {
         // Wait to make sure breakpoint is created
         await event;
 
-        event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        event = dc.waitForEvent('breakpoint');
         // Modify the breakpoint from the debug-console/terminal
         await dc.evaluateRequest({
             expression: `>disable 1`,
@@ -100,7 +101,7 @@ describe('breakpoints', async function () {
         // Run a configuration Done Request to inform the adapter that the client is done
         await dc.configurationDoneRequest();
 
-        expect(outputs.body.message).eq('Breakpoint-modified');
+        expect(outputs.body.reason).eq('changed');
     });
 
     it('should handle a breakpoint deletion from the debug-console/terminal', async function () {
@@ -112,10 +113,10 @@ describe('breakpoints', async function () {
         /* 
             Create an event variable that will eventually wait for the custom event being sent when a breakpoint is created
             Just using 
-            await dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView'); 
+            await dc.waitForEvent('breakpoint'); 
             is NOT enough, as it misses the event from the adapter due to misalignment issues
         */
-        event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        event = dc.waitForEvent('breakpoint');
         // Create a breakpoint from the debug-console/Terminal
         await dc.evaluateRequest({
             expression: `>break ${testProgramsDir}/count.c:4`,
@@ -125,7 +126,7 @@ describe('breakpoints', async function () {
         // Wait to make sure breakpoint is created
         await event;
 
-        event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        event = dc.waitForEvent('breakpoint');
         // Modify the breakpoint from the debug-console/terminal
         await dc.evaluateRequest({
             expression: `>delete 1`,
@@ -136,7 +137,7 @@ describe('breakpoints', async function () {
         // Run a configuration Done Request to inform the adapter that the client is done
         await dc.configurationDoneRequest();
 
-        expect(outputs.body.message).eq('Breakpoint-deleted');
+        expect(outputs.body.reason).eq('removed');
     });
 
     it('set breakpoints from terminal without GUI reflection will auto erase the bp', async function () {
@@ -148,7 +149,7 @@ describe('breakpoints', async function () {
 
         // Setting a breakpoint from the debug-console/terminal without reflecting on GUI,
         // it should be erased when setBreakpointsRequest is called
-        const event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        const event = dc.waitForEvent('breakpoint');
         await dc.evaluateRequest({
             expression: `>break ${testProgramsDir}/count.c:4`,
             frameId: scope.frame.id,
@@ -194,7 +195,7 @@ describe('breakpoints', async function () {
         const scope = await getScopes(dc);
 
         // Setting a breakpoint from the debug-console/terminal
-        const event = dc.waitForEvent('cdt-gdb-adapter/UpdateBreakpointView');
+        const event = dc.waitForEvent('breakpoint');
         await dc.evaluateRequest({
             expression: `>break ${testProgramsDir}/count.c:4`,
             frameId: scope.frame.id,

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -91,6 +91,25 @@ describe('evaluate request', function () {
         await event;
     });
 
+    it('should not send a warning when evaluating an enable/disable breakpoint command is sent', async function () {
+        const event = dc.waitForOutputEvent(
+            'stdout',
+            'warning: "enable" and "disable" commands cannot be reflected in the GUI'
+        );
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: '> enable mem',
+            frameId: scope.frame.id,
+        });
+        const output = await Promise.race([
+            event,
+            new Promise<undefined>((resolve) =>
+                setTimeout(() => resolve(undefined), 1000)
+            ),
+        ]);
+        expect(output).eq(undefined);
+    });
+
     it('should be able to update the value of a variable named monitor and that variable has local scope', async function () {
         const res1 = await dc.evaluateRequest({
             context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -77,6 +77,17 @@ describe('evaluate request', function () {
 
         expect(err.body.result).eq('Error: could not evaluate expression');
     });
+
+    it('should send a warning when evaluating an enable/disable breakpoint command is sent', async function () {
+        const event = dc.waitForOutputEvent('stdout', 'warning: "enable" and "disable" commands cannot be reflected in the GUI');
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: '> enable',
+            frameId: scope.frame.id,
+        });
+        await event;
+    });
+
     it('should be able to update the value of a variable named monitor and that variable has local scope', async function () {
         const res1 = await dc.evaluateRequest({
             context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -79,7 +79,10 @@ describe('evaluate request', function () {
     });
 
     it('should send a warning when evaluating an enable/disable breakpoint command is sent', async function () {
-        const event = dc.waitForOutputEvent('stdout', 'warning: "enable" and "disable" commands cannot be reflected in the GUI');
+        const event = dc.waitForOutputEvent(
+            'stdout',
+            'warning: "enable" and "disable" commands cannot be reflected in the GUI'
+        );
         await dc.evaluateRequest({
             context: 'repl',
             expression: '> enable',


### PR DESCRIPTION
Unfortunately enable/disable bp commands supported by GDB cannot be reflected in the GUI using the normal Breakpoint event.

For now, a warning message will be printed in the debug console to the user whenever these commands are being used