### PR TITLE
Changed evaluation of variables to functions of gdb

### DIFF
--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -440,36 +440,36 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], '[0]', 'int', '1', {
+        verifyVariable(children.body.variables[0], '0', 'int', '1', {
             hasMemoryReference: false,
         });
-        verifyVariable(children.body.variables[1], '[1]', 'int', '2', {
+        verifyVariable(children.body.variables[1], '1', 'int', '2', {
             hasMemoryReference: false,
         });
-        verifyVariable(children.body.variables[2], '[2]', 'int', '3', {
+        verifyVariable(children.body.variables[2], '2', 'int', '3', {
             hasMemoryReference: false,
         });
         // set the variables to something different
         const set0inHex = await dc.setVariableRequest({
-            name: '[0]',
+            name: '0',
             value: '0x11',
             variablesReference: childVR,
         });
         expect(set0inHex.body.value).to.equal('17');
         const set0 = await dc.setVariableRequest({
-            name: '[0]',
+            name: '0',
             value: '11',
             variablesReference: childVR,
         });
         expect(set0.body.value).to.equal('11');
         const set1 = await dc.setVariableRequest({
-            name: '[1]',
+            name: '1',
             value: '22',
             variablesReference: childVR,
         });
         expect(set1.body.value).to.equal('22');
         const set2 = await dc.setVariableRequest({
-            name: '[2]',
+            name: '2',
             value: '33',
             variablesReference: childVR,
         });
@@ -480,13 +480,13 @@ describe('Variables Test Suite', function () {
             children.body.variables.length,
             'There is a different number of child variables than expected'
         ).to.equal(3);
-        verifyVariable(children.body.variables[0], '[0]', 'int', '11', {
+        verifyVariable(children.body.variables[0], '0', 'int', '11', {
             hasMemoryReference: false,
         });
-        verifyVariable(children.body.variables[1], '[1]', 'int', '22', {
+        verifyVariable(children.body.variables[1], '1', 'int', '22', {
             hasMemoryReference: false,
         });
-        verifyVariable(children.body.variables[2], '[2]', 'int', '33', {
+        verifyVariable(children.body.variables[2], '2', 'int', '33', {
             hasMemoryReference: false,
         });
         // step the program and see that the values were passed to the program and evaluated.

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -63,6 +63,11 @@ export interface MIVarAssignResponse {
     value: string;
 }
 
+export interface MIVarInfoResponse {
+    exp: string;
+    lang: string;
+}
+
 export interface MIVarPathInfoResponse {
     path_expr: string;
 }
@@ -186,6 +191,14 @@ export function sendVarEvaluateExpression(
     }
 ): Promise<MIVarEvalResponse> {
     const command = `-var-evaluate-expression ${params.varname}`;
+    return gdb.sendCommand(command);
+}
+
+export function sendVarInfoExpression(
+    gdb: IGDBBackend,
+    name: string
+): Promise<MIVarInfoResponse> {
+    const command = `-var-info-expression ${name}`;
     return gdb.sendCommand(command);
 }
 


### PR DESCRIPTION
While adding "gdbtarget" to the extension "RTOS Viewer" I was wondering about the relatively complex handling of variable evaluation inside function handleVariableRequestObject() in src/gdb/GDBDebugSessionBase.ts. The issue was, that some of the RTOS variables could not be evaluated because of the array handling. Struct members were encapsulated into [] brackets where they shouldn't.

I refactored parts of that module to use gdb mi commands, see: https://sourceware.org/gdb/current/onlinedocs/gdb.html/GDB_002fMI-Variable-Objects.html
-var-info-expression (for display elements)
-var-info-path-expression (to create and store expressions)

A "major" change is, that array elements are now displayed as "0 = ..." instaed of "[0] = ...".

After this change, the RTOS Viewer displayed FreeRTOS, and my tests with global nested struct / array variables did not show any issue.