### PR TITLE
Fix variales array expression

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2104,7 +2104,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 let name = `${ref.varobjName}.${child.exp}`;
                 const varobjName = name;
                 const value = child.value ? child.value : child.type;
-                const isArrayParent = arrayRegex.test(child.type);
+                const isArrayParent = arrayRegex.test(child.type) && arrayChildRegex.test(child.exp);
                 if(isArrayParent) {
                     console.log(`Found array parent: ${name}`);
                 }
@@ -2119,7 +2119,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 const variableName = isArrayChild ? name : child.exp;
                 const evaluateName =
-                    (isArrayParent || isArrayChild) && numberRegex.test(child.exp)
+                    isArrayParent || isArrayChild
                         ? `${topLevelPathExpression}[${child.exp}]`
                         : `${topLevelPathExpression}.${child.exp}`;
                 variables.push({

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2105,6 +2105,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 const varobjName = name;
                 const value = child.value ? child.value : child.type;
                 const isArrayParent = arrayRegex.test(child.type);
+                if(isArrayParent) {
+                    console.log(`Found array parent: ${name}`);
+                }
                 const isArrayChild =
                     varobj !== undefined
                         ? arrayRegex.test(varobj.type) &&
@@ -2116,7 +2119,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 const variableName = isArrayChild ? name : child.exp;
                 const evaluateName =
-                    isArrayParent || isArrayChild
+                    (isArrayParent || isArrayChild) && numberRegex.test(child.exp)
                         ? `${topLevelPathExpression}[${child.exp}]`
                         : `${topLevelPathExpression}.${child.exp}`;
                 variables.push({


### PR DESCRIPTION
While adapting RTOS Viewer Extension for gdbtarget, I figured out that some variable expressions are turned into array expressions where they imho should not. A struct or array member which is an array itself gets [] for the access expression, which results in an expression: `((TCB_t*)0x20005cd0)[pcTaskName]`, where `pcTaskName` is a char [16] array.

I have changed this to use GDB directly, but this could cause bandwidth issues when running GDB remotely, see: https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/390

If I got it correctly,
- `isArrayParent` determines if the element itself is an array
- `isArrayChild` determines if the element is part of an array

I want to understand why `isArrayParent` elements also gets brackets `[]`. I thought about two-dimensional arrays, but they run fine on just using `isArrayChild`.

This change for arrayParent fixes the issue on parsing (my) expressions and survives 2D arrays:
`const isArrayParent = arrayRegex.test(child.type) && arrayChildRegex.test(child.exp);`

@asimgunes, @jonahgraham, can someone bring some light into the darkness?
