### PR TITLE
Improve Breakpoint Error Logging

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -63,7 +63,7 @@ const cNumberTypeRegex = /\b(?:char|short|int|long|float|double)$/; // match C n
 const cBoolRegex = /\bbool$/; // match boolean
 
 // Interface for output category pair
-interface OutputCategory {
+interface StreamOutput {
     output: string;
     category: string;
 }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -270,7 +270,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
     }
-    private async switchOutputToError (output : string) : Promise<void> {
+    private async switchOutputToError(output: string): Promise<void> {
         this.sendEvent(new OutputEvent(output, 'stderr'));
     }
     protected async setupCommonLoggerAndBackends(
@@ -285,10 +285,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.gdb = await this.backendFactory.createBackend(this, manager, args);
 
         this.gdb.on('consoleStreamOutput', (output, category) => {
-            if (
-                output.startsWith('Cannot insert hardware breakpoint')
-            ) {
-                const outputToError = 'Breakpoint number limit is reached, erase extra breakpoints to be able to resume debugging';
+            if (output.startsWith('Cannot insert hardware breakpoint')) {
+                const outputToError =
+                    'Breakpoint number limit is reached, erase extra breakpoints';
                 this.switchOutputToError(outputToError);
             } else {
                 this.sendEvent(new OutputEvent(output, category));

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -280,10 +280,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     private switchOutputToError(
         input: string,
         category: string
-    ): OutputCategory {
+    ): StreamOutput {
         const outputToError =
-            'Breakpoint number limit is reached, erase extra breakpoints';
-        const returnPair: OutputCategory = input.startsWith(
+            'HW breakpoint limit reached, reduce set breakpoints';
+        const returnPair: StreamOutput = input.startsWith(
             'Cannot insert hardware breakpoint'
         )
             ? { output: outputToError, category: 'stderr' }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -277,10 +277,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    private switchOutputToError(
-        input: string,
-        category: string
-    ): StreamOutput {
+    private switchOutputToError(input: string, category: string): StreamOutput {
         const outputToError =
             'HW breakpoint limit reached, reduce set breakpoints';
         const returnPair: StreamOutput = input.startsWith(


### PR DESCRIPTION
Problem:
When a user is using remote GDB and tries to set more than the amount of HW breakpoints, GDB sends a warning message and cannot step anymore.

Solution:
I created this PR, where a red error message will be printed to the user to ask for the extra breakpoints to be erased.

Future work:
When the user sets all of the breakpoints before starting the debug session the adapter sends an error message to VSCode, which in turn triggers a disconnect request back to the adapter. This should be mitigated somehow for a consistent behaviour between before and after the debug session starts