### PR TITLE
Allow attaching (remote and local) with no program

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -169,8 +169,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;
             if (
-                launchArgs.target?.serverParameters === undefined &&
-                !launchArgs.program
+                launchArgs.target?.serverParameters === undefined
             ) {
                 this.sendErrorResponse(
                     response,
@@ -534,9 +533,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             });
 
             // Load files and configure GDB
-            await this.executeOrAbort(
-                this.gdb.sendFileExecAndSymbols.bind(this.gdb)
-            )(args.program);
+            if(args.program !== undefined && args.program !== '') {
+                await this.executeOrAbort(
+                    this.gdb.sendFileExecAndSymbols.bind(this.gdb)
+                )(args.program);
+            }
             await this.executeOrAbort(
                 this.gdb.sendEnablePrettyPrint.bind(this.gdb)
             )();

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -168,16 +168,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;
-            if (
-                launchArgs.target?.serverParameters === undefined
-            ) {
-                this.sendErrorResponse(
-                    response,
-                    1,
-                    'The program must be specified in the launch request arguments'
-                );
-                return;
-            }
             await this.startGDBServer(launchArgs);
         }
         await this.startGDBAndAttachToTarget(response, args);

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -302,15 +302,19 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         await this.setupCommonLoggerAndBackends(args);
 
         await this.spawn(args);
-        if (!args.program) {
-            this.sendErrorResponse(
-                response,
-                1,
-                'The program must be specified in the request arguments'
-            );
-            return;
+        if (request == 'launch') {
+            if (!args.program) {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    'The program must be specified in the request arguments'
+                );
+                return;
+            }
         }
-        await this.gdb.sendFileExecAndSymbols(args.program);
+        if (args.program) {
+            await this.gdb.sendFileExecAndSymbols(args.program);
+        }
         await this.gdb.sendEnablePrettyPrint();
 
         if (request === 'attach') {

--- a/src/integration-tests/attach.spec.ts
+++ b/src/integration-tests/attach.spec.ts
@@ -51,4 +51,17 @@ describe('attach', function () {
         await dc.attachHitBreakpoint(attachArgs, { line: 25, path: src });
         expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
     });
+
+    it('can attach and hit a breakpoint with no program specified', async function () {
+        if (isRemoteTest) {
+            // attachRemote.spec.ts is the test for when isRemoteTest
+            this.skip();
+        }
+
+        const attachArgs = fillDefaults(this.test, {
+            processId: `${inferior.pid}`,
+        } as AttachRequestArguments);
+        await dc.attachHitBreakpoint(attachArgs, { line: 25, path: src });
+        expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
+    });
 });

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -40,6 +40,7 @@ describe('attach remote', function () {
                 cwd: testProgramsDir,
             }
         );
+        port = '';  // reset port
         port = await new Promise<string>((resolve, reject) => {
             const regex = new RegExp(/Listening on port ([0-9]+)\r?\n/);
             let accumulatedStderr = '';

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -10,6 +10,7 @@
 
 import * as cp from 'child_process';
 import * as path from 'path';
+import * as os from 'os';
 import {
     TargetAttachRequestArguments,
     TargetAttachArguments,
@@ -67,6 +68,21 @@ describe('attach remote', function () {
     it('can attach remote and hit a breakpoint', async function () {
         const attachArgs = fillDefaults(this.test, {
             program: emptyProgram,
+            target: {
+                type: 'remote',
+                parameters: [`localhost:${port}`],
+            } as TargetAttachArguments,
+        } as TargetAttachRequestArguments);
+        await dc.attachHitBreakpoint(attachArgs, { line: 3, path: emptySrc });
+        expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
+    });
+
+    it('can attach remote and hit a breakpoint without a program', async function () {
+        if (os.platform() === 'win32') {
+            // win32 host does support this use case
+            this.skip();
+        }
+        const attachArgs = fillDefaults(this.test, {
             target: {
                 type: 'remote',
                 parameters: [`localhost:${port}`],

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -158,8 +158,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;
             if (
-                launchArgs.target?.serverParameters === undefined &&
-                !launchArgs.program
+                launchArgs.target?.serverParameters === undefined
             ) {
                 this.sendErrorResponse(
                     response,
@@ -403,13 +402,14 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             });
 
             // Load files and configure GDB
-            await this.executeOrAbort(
-                this.gdb.sendFileExecAndSymbols.bind(this.gdb)
-            )(args.program);
-            await this.executeOrAbort(
-                this.gdb.sendEnablePrettyPrint.bind(this.gdb)
-            )();
-
+            if(args.program !== undefined && args.program !== '') {
+                await this.executeOrAbort(
+                    this.gdb.sendFileExecAndSymbols.bind(this.gdb)
+                )(args.program);
+                await this.executeOrAbort(
+                    this.gdb.sendEnablePrettyPrint.bind(this.gdb)
+                )();
+            }
             if (args.imageAndSymbols) {
                 if (args.imageAndSymbols.symbolFileName) {
                     if (args.imageAndSymbols.symbolOffset) {

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -157,16 +157,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;
-            if (
-                launchArgs.target?.serverParameters === undefined
-            ) {
-                this.sendErrorResponse(
-                    response,
-                    1,
-                    'The program must be specified in the launch request arguments'
-                );
-                return;
-            }
             await this.startGDBServer(launchArgs);
         }
 


### PR DESCRIPTION
Picked up a PR from @jonahgraham to allow a debug session to connect when no program is specified.

Ref.: https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/262