### PR TITLE
Run format-check before tests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,6 +27,8 @@ jobs:
           sudo sysctl kernel.yama.ptrace_scope=0
       - name: Build
         run: yarn
+      - name: Verify code formatting is valid
+        run: yarn format-check
       - name: Build Test Programs
         run: make -C src/integration-tests/test-programs
       - name: Test
@@ -44,8 +46,6 @@ jobs:
           name: test-results-ubuntu
           path: 'test-reports/*.xml'
           retention-days: 1
-      - name: Verify code formatting is valid
-        run: yarn format-check
       - name: Verify no unexpected changes to source tree
         run: git diff --exit-code
   Build-on-Windows:


### PR DESCRIPTION
Small change but hopefully big development efficiency improvement:
Run the prettier format check before running tests on Linux rather than after.
This should save us an ~8 minute waiting time to find out we forgot to run `yarn format` before commit.