### PR TITLE
cdt-gdb-vscode 173: Add `watchServerProcess` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
-# Unreleased
-
+- Fixes [cdt-gdb-vscode 173](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/173): Add `target`>`watchServerProcess` to ignore early exit of `server` executable, e.g. if a launcher for the actual gdbserver.
 - Fixes [#398](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/398): Give gdbserver time to gracefully disconnect before terminating it
 
 ## 1.1.0

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -87,6 +87,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     protected gdbserverProcessManager?: IGDBServerProcessManager;
     // Capture if gdbserver was launched for correct disconnect behavior
     protected launchGdbServer = false;
+    protected watchGdbServer = true;
     protected killGdbServer = true;
     protected serverDisconnectTimeout = 1000;
     protected sessionInfo: SessionInfo = {
@@ -224,6 +225,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         const target = args.target;
 
         this.launchGdbServer = true;
+        this.watchGdbServer = target.watchServerProcess ?? true;
         this.killGdbServer = target.automaticallyKillServer !== false;
         this.serverDisconnectTimeout =
             target.serverDisconnectTimeout !== undefined &&
@@ -337,8 +339,10 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     this.sessionInfo.disconnectError =
                         'GDB server exited unexpectedly, see Debug Console for more info';
                 }
-                this.logGDBRemote('GDB server exited, exiting session');
-                await this.setExitSessionRequest(ExitSessionRequest.EXIT);
+                if (this.watchGdbServer) {
+                    this.logGDBRemote('GDB server exited, exiting session');
+                    await this.setExitSessionRequest(ExitSessionRequest.EXIT);
+                }
             });
 
             this.gdbserver.on('error', (err) => {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -142,6 +142,8 @@ export interface TargetLaunchArguments extends TargetAttachArguments {
     // Delay after startup before continuing launch, in milliseconds. If serverPortRegExp is
     // provided, it is the delay after that regexp is seen.
     serverStartupDelay?: number;
+    // Watch server process and handle when it (unexpectedly) exists (default: true)
+    watchServerProcess?: boolean;
     // Automatically kill the launched server when client issues a disconnect (default: true)
     automaticallyKillServer?: boolean;
     // Specifies the working directory of gdbserver, defaults to cwd in RequestArguments

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -81,6 +81,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     protected gdbserverProcessManager?: IGDBServerProcessManager;
     // Capture if gdbserver was launched for correct disconnect behavior
     protected launchGdbServer = false;
+    protected watchGdbServer = true;
     protected killGdbServer = true;
     protected sessionInfo: SessionInfo = {
         state: SessionState.INACTIVE,
@@ -210,6 +211,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         const target = args.target;
 
         this.launchGdbServer = true;
+        this.watchGdbServer = target.watchServerProcess ?? true;
         this.killGdbServer = target.automaticallyKillServer !== false;
 
         // Wait until gdbserver is started and ready to receive connections.
@@ -312,8 +314,10 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     this.sessionInfo.disconnectError =
                         'GDB server exited unexpectedly, see Debug Console for more info';
                 }
-                this.logGDBRemote('GDB server exited, exiting session');
-                await this.setExitSessionRequest(ExitSessionRequest.EXIT);
+                if (this.watchGdbServer) {
+                    this.logGDBRemote('GDB server exited, exiting session');
+                    await this.setExitSessionRequest(ExitSessionRequest.EXIT);
+                }
             });
 
             this.gdbserver.on('error', (err) => {


### PR DESCRIPTION
Fixes [Regression in version 2.1.0: Remote debugging with gdbtarget no longer starts correctly](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/173)

Adds a new setting `target`>`watchServerProcess` to monitor and handle the gdbserver process state, e.g. if unexpected early exists. Defaults to `true`, use to ignore such unexpected changes in the gdbserver process state. For example of `target`>`server` is a launcher for the actual gdbserver.