### PR TITLE
Fix getting stuck on concurrent breakpoint setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixes [`#407`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/407): Getting stuck on concurrent breakpoint setup on targets that don’t stop on attach.
 - Fixes [`#427`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/427): Breakpoint source code reference to module disappears when breakpoint is hit
 
 ## 1.2.0

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -9,12 +9,7 @@
  *********************************************************************/
 
 import { GDBDebugSession } from './GDBDebugSession';
-import {
-    InitializedEvent,
-    logger,
-    OutputEvent,
-    TerminatedEvent,
-} from '@vscode/debugadapter';
+import { logger, OutputEvent, TerminatedEvent } from '@vscode/debugadapter';
 import { LogLevel } from '@vscode/debugadapter/lib/logger';
 import * as mi from '../mi';
 import * as os from 'os';
@@ -645,10 +640,9 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             );
             // Connection completed, announce the adapter is ready for
             // other protocol commands.
-            this.sendEvent(new InitializedEvent());
+            this.sendInitializedEvent();
             this.sendResponse(response);
             await this.setSessionState(SessionState.SESSION_READY);
-            this.isInitialized = true;
         } catch (err) {
             this.logGDBRemote(`caught error '${err}`);
             // Clean up any pending processes

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -55,6 +55,27 @@ class ThreadWithStatus implements DebugProtocol.Thread {
     }
 }
 
+/**
+ * Keeps track of where in the configuration phase (between initialized event
+ * and configurationDone response) we are.
+ */
+const enum ConfiguringState {
+    /** Configuration phase has not started yet. */
+    INITIAL,
+    /** Configuration phase has started, target is running, no requests that
+     * require pausing it have arrived yet. */
+    CONFIGURING,
+    /** Configuration phase has started, at least one request that requires
+     * pausing the target has arrived or it has been paused to begin with. */
+    CONFIGURING_PAUSED,
+    /** Configuration phase is completed, the next unpausing is the one
+     * associated with the end of the phase. */
+    FINISHING,
+    /** Configuration phase is completed, any following unpausing corresponds
+     * to a pausing outside of the configuration phase. */
+    DONE,
+}
+
 // Allow a single number for ignore count or the form '> [number]'
 const ignoreCountRegex = /\s|>/g;
 const arrayRegex = /.*\[[\d]+\].*/;
@@ -135,6 +156,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     // reference count of operations requiring pausing, to make sure only the
     // first of them pauses, and the last to complete resumes
     protected pauseCount = 0;
+    // keeps track of where in the configuration phase (between initialize event
+    // and configurationDone response) we are
+    protected configuringState: ConfiguringState = ConfiguringState.INITIAL;
     protected isInitialized = false;
 
     /**
@@ -365,8 +389,18 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 });
             }
         }
-        this.sendEvent(new InitializedEvent());
+        this.sendInitializedEvent();
         this.sendResponse(response);
+    }
+
+    protected sendInitializedEvent() {
+        if (this.isRunning) {
+            this.configuringState = ConfiguringState.CONFIGURING;
+        } else {
+            this.configuringState = ConfiguringState.CONFIGURING_PAUSED;
+            this.pauseCount++;
+        }
+        this.sendEvent(new InitializedEvent());
         this.isInitialized = true;
     }
 
@@ -433,6 +467,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async pauseIfNeeded(requireAsync: true): Promise<void>;
 
     protected async pauseIfNeeded(requireAsync = false): Promise<void> {
+        // If we are in the configuration phase and this is the first request
+        // that requires pausing, add another pauseIfNeeded/continueIfNeeded
+        // bracket around the whole phase so we don't unnecessarily pause/
+        // continue more than once. Matching continueIfNeeded is in
+        // configurationDoneRequest.
+        if (this.configuringState === ConfiguringState.CONFIGURING) {
+            this.configuringState = ConfiguringState.CONFIGURING_PAUSED;
+            this.pauseIfNeeded(); // no need to await
+        }
+
         this.pauseCount++;
         if (this.pauseCount === 1) {
             this.waitPausedNeeded =
@@ -476,7 +520,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         if (this.pauseCount > 0) {
             this.pauseCount--;
             if (this.pauseCount === 0) {
-                if (this.waitPausedNeeded) {
+                if (this.configuringState === ConfiguringState.FINISHING) {
+                    this.configuringState = ConfiguringState.DONE;
+                    if (this.isAttach) {
+                        await mi.sendExecContinue(this.gdb);
+                    } else {
+                        await mi.sendExecRun(this.gdb);
+                    }
+                } else if (this.waitPausedNeeded) {
                     if (this.gdb.isNonStopMode()) {
                         await mi.sendExecContinue(this.gdb, this.waitPausedThreadId);
                     } else {
@@ -973,10 +1024,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     'console'
                 )
             );
-            if (this.isAttach) {
-                await mi.sendExecContinue(this.gdb);
+            if (this.configuringState === ConfiguringState.CONFIGURING_PAUSED) {
+                this.configuringState = ConfiguringState.FINISHING;
+                await this.continueIfNeeded();
             } else {
-                await mi.sendExecRun(this.gdb);
+                this.configuringState = ConfiguringState.DONE;
             }
             this.sendResponse(response);
         } catch (err) {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -501,7 +501,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 if (this.gdb.isNonStopMode()) {
                     if (this.waitPausedThreadId === 0) {
-                        this.waitPausedThreadId = await this.gdb.queryCurrentThreadId();
+                        this.waitPausedThreadId =
+                            await this.gdb.queryCurrentThreadId();
                     }
                     this.gdb.pause(this.waitPausedThreadId);
                 } else {
@@ -529,7 +530,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     }
                 } else if (this.waitPausedNeeded) {
                     if (this.gdb.isNonStopMode()) {
-                        await mi.sendExecContinue(this.gdb, this.waitPausedThreadId);
+                        await mi.sendExecContinue(
+                            this.gdb,
+                            this.waitPausedThreadId
+                        );
                     } else {
                         await mi.sendExecContinue(this.gdb);
                     }

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -9,12 +9,7 @@
  *********************************************************************/
 
 import { GDBDebugSession } from './GDBDebugSession';
-import {
-    InitializedEvent,
-    logger,
-    OutputEvent,
-    TerminatedEvent,
-} from '@vscode/debugadapter';
+import { logger, OutputEvent, TerminatedEvent } from '@vscode/debugadapter';
 import { LogLevel } from '@vscode/debugadapter/lib/logger';
 import * as mi from '../mi';
 import { DebugProtocol } from '@vscode/debugprotocol';
@@ -489,10 +484,9 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             );
             // Connection completed, announce the adapter is ready for
             // other protocol commands.
-            this.sendEvent(new InitializedEvent());
+            this.sendInitializedEvent();
             this.sendResponse(response);
             await this.setSessionState(SessionState.SESSION_READY);
-            this.isInitialized = true;
         } catch (err) {
             this.logGDBRemote(`caught error '${err}`);
             // Clean up any pending processes


### PR DESCRIPTION
### Problem

After being prompted using the `initialized` event, VS Code sends us `setBreakpoints`, `setFunctionBreakpoints`, and `setInstructionBreakpoints` requests in quick succession, without waiting for each to complete. The current code in `pauseIfNeeded` is not prepared for that, it can only deal with one request at a time. The immediate symptom is that when attaching to our embedded system, starting the debug session hangs.

The failure is only seen with targets that do not automatically stop all threads on attaching, so `pauseIfNeeded` actually does anything, such as ours (an embedded system behind our own GDB stub), unlike what gdb and gdbserver do when attaching to a Unix process. That is probably the reason why the problem has not been noticed previously.

### Analysis and proposed changes

The **first commit** adds a test, currently failing, that demonstrates the problem. It simulates such a target by issuing an `-exec-continue` right after attaching. It works in both all-stop and non-stop mode, although the situation I am interested in (used with our embedded target) is non-stop mode. Let me know if this test could be done better differently or elsewhere, I am still feeling my way around how the tests work.

What specifically happens is that when the second call to `pauseIfNeeded` arrives, it overwrites the previous `waitPaused` resolve function, and the first call then waits indefinitely on a promise that never resolves because its resolve function was lost.

This is fixed in the **second commit** by daisy-chaining the previous resolve function on the new promise.

That gets us a little further, however, we still redundantly issue three thread info requests and pause requests to GDB in a row when one would be sufficient, and worse, the first `continueIfNeeded` call from whichever of the three breakpoint requests completes first already ends the pause even though the other two are not done with their work yet (in my case, that does not cause any disruption, because our stub is capable of setting breakpoints with running threads). The second and third `continueIfNeeded` calls are answered by GDB with `error,msg="Cannot execute this command while the selected thread is running."`, although that doesn’t seem to be bothering anyone at this point.

There is an additional extra `sendExecContinue` in `configurationDoneRequest` whose `error,msg="Cannot execute this command while the selected thread is running."` response finally shuts down the debug session before it has a chance to become useful, but that will be dealt with further below.

The **third commit** fixes the redundant requests and early unpausing by introducing a reference count of active pause requests, so that only the first call to `pauseIfNeeded` will start a pause, and only the last call to `continueIfNeeded` will end it.

That still leaves the imperfection that if the breakpoint requests were to arrive not concurrently but sequentially (which they do not in my experience, but the protocol would allow it), with all previous ones complete before the next one arrives, we would still unnecessarily pause and continue multiple times, because the refcount would go to zero in between.

This is fixed by the **fourth commit**: During the configuration phase (which is the time span bounded by the `initialize` event and the `configurationDone` response), if and when the first request that requires pausing the target arrives, add another outer bracket of `pauseIfNeeded`/`continueIfNeeded` around the whole remainder of the phase, so that the refcount never goes to zero in between. As a side effect, this also fixes the extra `sendExecContinue` that previously killed the debug session, which is now covered by that final `continueIfNeeded`.

### Notes

I am a little puzzled about how this can ever have worked for anyone working on embedded systems, which seems to be the majority audience here. Does everyone stop their embedded system when attaching a debugger? I hope I am not breaking those people’s use cases in turn (tests still pass though).

I am planning to do further work in this area, but that is for separate PRs:
- I would like to make this pausing business optional, because our stub and target is capable of setting breakpoints without pausing any threads, and in fact we must not (even temporarily) pause arbitrary threads on attaching, because that could wreak havoc on the real-time behavior of a running industrial machine.
- The debug adapter protocol is not implemented correctly in that the `launch`/`attach` response is not delayed until after the `configurationDone` response as specified (clearly) in https://github.com/microsoft/vscode/issues/4902#issuecomment-368583522 and (a little less clearly, in my opinion) in the [protocol specs](https://microsoft.github.io/debug-adapter-protocol/overview#launch-sequencing).