### PR TITLE
Unifying Error message between Windows and macOS in the case of Target Attaching error

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -633,8 +633,17 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             // Complete connection failure response
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            if(process.platform === 'win32' && errorMessage.startsWith('could not connect (error 138): The system tried to join a drive')) {
-                this.sendErrorResponse(response, 1, 'could not connect: Operation timed out.');    
+            if (
+                process.platform === 'win32' &&
+                errorMessage.startsWith(
+                    'could not connect (error 138): The system tried to join a drive'
+                )
+            ) {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    'could not connect: Operation timed out.'
+                );
             } else {
                 this.sendErrorResponse(response, 1, errorMessage);
             }

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -633,7 +633,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             // Complete connection failure response
             const errorMessage =
                 err instanceof Error ? err.message : String(err);
-            this.sendErrorResponse(response, 1, errorMessage);
+            if(process.platform === 'win32' && errorMessage.startsWith('could not connect (error 138): The system tried to join a drive')) {
+                this.sendErrorResponse(response, 1, 'could not connect: Operation timed out.');    
+            } else {
+                this.sendErrorResponse(response, 1, errorMessage);
+            }
         }
     }
 


### PR DESCRIPTION
In the `gdbtarget` mode, whenever there is gdbserver timeout error, the GDB-Adapter would always print the error message provided by GDB.

on macOS, the message is `could not connect: Operation timed out.`
on Windows, the message is `could not connect (error 138): The system tried to join a drive to a directory on a joined drive.`

That difference between platforms is not something that we would want for our users, and also the Windows error message is not very descriptive to the actual cause of the error.

I unified the error message to be always `could not connect: Operation timed out.`