### PR TITLE
Allow sending commands to gdb in TargetDebug mode while target is running

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -752,4 +752,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             );
         }
     }
+
+    protected async evaluateRequest(
+        response: DebugProtocol.EvaluateResponse,
+        args: DebugProtocol.EvaluateArguments
+    ): Promise<void> {
+        return this.doEvaluateRequest(response, args, true);
+    }
 }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1386,7 +1386,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async doEvaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments,
-        allowIncompleteCommand?: boolean
+        allowIncompleteCommand: boolean
     ): Promise<void> {
         response.body = {
             result: 'Error: could not evaluate expression',

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1385,14 +1385,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async doEvaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments,
-        allowIncompleteCommand: boolean // if true, allows evaluation of expression without a frameId
+        alwaysAllowCliCommand: boolean // if true, allows evaluation of expression without a frameId
     ): Promise<void> {
         response.body = {
             result: 'Error: could not evaluate expression',
             variablesReference: 0,
         }; // default response
         try {
-            if (!allowIncompleteCommand && args.frameId === undefined) {
+            const allowCliCommand =
+                alwaysAllowCliCommand && args.expression.startsWith('>');
+
+            if (!allowCliCommand && args.frameId === undefined) {
                 throw new Error(
                     'Evaluation of expression without frameId is not supported.'
                 );
@@ -1402,7 +1405,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 ? this.frameHandles.get(args.frameId)
                 : undefined;
 
-            if (!allowIncompleteCommand && !frameRef) {
+            if (!allowCliCommand && !frameRef) {
                 this.sendResponse(response);
                 return;
             }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1385,7 +1385,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async doEvaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments,
-        allowIncompleteCommand: boolean
+        allowIncompleteCommand: boolean // if true, allows evaluation of expression without a frameId
     ): Promise<void> {
         response.body = {
             result: 'Error: could not evaluate expression',

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -273,7 +273,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.supportsWriteMemoryRequest = true;
         response.body.supportsSteppingGranularity = true;
         response.body.supportsInstructionBreakpoints = true;
-        response.body.supportsTerminateRequest = true;
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
     }

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -15,6 +15,7 @@ import {
     expectRejection,
     fillDefaults,
     getScopes,
+    isRemoteTest,
     Scope,
     standardBeforeEach,
     testProgramsDir,
@@ -56,6 +57,10 @@ describe('evaluate request', function () {
     });
 
     it('should reject evaluation of expression without a frame', async function () {
+        if(isRemoteTest) {
+            return;
+        }
+        
         const err = await expectRejection(
             dc.evaluateRequest({
                 context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -58,7 +58,7 @@ describe('evaluate request', function () {
 
     it('should reject evaluation of expression without a frame', async function () {
         if (isRemoteTest) {
-            return;
+            this.skip();
         }
 
         const err = await expectRejection(

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -57,10 +57,10 @@ describe('evaluate request', function () {
     });
 
     it('should reject evaluation of expression without a frame', async function () {
-        if(isRemoteTest) {
+        if (isRemoteTest) {
             return;
         }
-        
+
         const err = await expectRejection(
             dc.evaluateRequest({
                 context: 'repl',

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -156,4 +156,26 @@ describe('launch remote', function () {
             true
         );
     });
+
+    it('should not reject evaluation of expression without a frame', async function () {
+        await dc.hitBreakpoint(
+            fillDefaults(this.test, {
+                program: emptyProgram,
+                target: {
+                    type: 'remote',
+                } as TargetLaunchArguments,
+            } as TargetLaunchRequestArguments),
+            {
+                path: emptySrc,
+                line: 3,
+            }
+        );
+
+        const ret = await dc.evaluateRequest({
+            context: 'repl',
+            expression: '>help',
+        });
+        expect(ret.body.result).to.include('\r');
+        expect(ret.command).to.include('evaluate');
+    });
 });

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -23,6 +23,7 @@ describe('launch remote', function () {
     let dc: CdtDebugClient;
     const emptyProgram = path.join(testProgramsDir, 'empty');
     const emptySrc = path.join(testProgramsDir, 'empty.c');
+    const loopForeverProgram = path.join(testProgramsDir, 'loopforever');
 
     beforeEach(async function () {
         dc = await standardBeforeEach('debugTargetAdapter.js');
@@ -157,18 +158,14 @@ describe('launch remote', function () {
         );
     });
 
-    it('should not reject evaluation of expression without a frame', async function () {
-        await dc.hitBreakpoint(
+    it.only('should not reject evaluation of expression without a frame', async function () {
+        await dc.launchRequest(
             fillDefaults(this.test, {
-                program: emptyProgram,
+                program: loopForeverProgram,
                 target: {
                     type: 'remote',
                 } as TargetLaunchArguments,
-            } as TargetLaunchRequestArguments),
-            {
-                path: emptySrc,
-                line: 3,
-            }
+            } as TargetLaunchRequestArguments)
         );
 
         const ret = await dc.evaluateRequest({

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -595,4 +595,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             );
         }
     }
+
+    protected async evaluateRequest(
+        response: DebugProtocol.EvaluateResponse,
+        args: DebugProtocol.EvaluateArguments
+    ): Promise<void> {
+        return this.doEvaluateRequest(response, args, true);
+    }
 }


### PR DESCRIPTION
When target (on gdb-server) is running, the cdt-gdb-adapter blocks all commands and expressions.
Work for this has already been prepared here: https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/383

Effectively this lets GDB decide if it can execute a command ior not.