### PR TITLE
Handle recovery from late out-of-band error arrivals

### DIFF
--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 import { Readable } from 'stream';
-import { logger, LogLevel } from '@vscode/debugadapter/lib/logger';
+import { logger } from '@vscode/debugadapter/lib/logger';
 import { IGDBBackend } from './types/gdb';
 import * as utf8 from 'utf8';
 
@@ -343,7 +343,12 @@ export class MIParser {
                     // If result is an out-of-band error, we expect this is handled higher up.
                     // In fact currently only expected for '-exec-*' commands. Hence, only print
                     // as error, if result class other than 'error' where this is genuinely unexpected.
-                    logger.log(`GDB response with no command: ${token}`, resultClass === 'error' ? LogLevel.Verbose : LogLevel.Error);
+                    const message = `GDB response with no command: ${token}`;
+                    if (resultClass === 'error') {
+                        logger.verbose(message);
+                    } else {
+                        logger.error(message);
+                    }
                 }
                 this.gdb.emit(
                     'resultAsync',

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 import { Readable } from 'stream';
-import { logger } from '@vscode/debugadapter/lib/logger';
+import { logger, LogLevel } from '@vscode/debugadapter/lib/logger';
 import { IGDBBackend } from './types/gdb';
 import * as utf8 from 'utf8';
 
@@ -340,7 +340,10 @@ export class MIParser {
                     command.callback(resultClass, resultData);
                     delete this.commandQueue[token];
                 } else {
-                    logger.error('GDB response with no command: ' + token);
+                    // If result is an out-of-band error, we expect this is handled higher up.
+                    // In fact currently only expected for '-exec-*' commands. Hence, only print
+                    // as error, if result class other than 'error' where this is genuinely unexpected.
+                    logger.log(`GDB response with no command: ${token}`, resultClass === 'error' ? LogLevel.Verbose : LogLevel.Error);
                 }
                 this.gdb.emit(
                     'resultAsync',

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -341,14 +341,12 @@ export class MIParser {
                     delete this.commandQueue[token];
                 } else {
                     logger.error('GDB response with no command: ' + token);
-                    if (resultClass === 'error') {
-                        this.gdb.emit(
-                            'errorAsync',
-                            resultClass,
-                            resultData
-                        );
-                    }
                 }
+                this.gdb.emit(
+                    'resultAsync',
+                    resultClass,
+                    resultData
+                );
                 break;
             }
             case '~':

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -12,8 +12,13 @@ import { logger } from '@vscode/debugadapter/lib/logger';
 import { IGDBBackend } from './types/gdb';
 import * as utf8 from 'utf8';
 
+interface Command {
+    command: string;
+    callback: (resultClass: string, resultData: any) => void;
+};
+
 type CommandQueue = {
-    [key: string]: (resultClass: string, resultData: any) => void;
+    [key: string]: Command;
 };
 
 export class MIParser {
@@ -30,7 +35,7 @@ export class MIParser {
         const entries = Object.entries(this.commandQueue);
         entries.forEach((entry) => {
             // Call callback with error to reject command promise
-            entry[1]('error', { msg: 'MI parser command queue cancelled' });
+            entry[1].callback('error', { msg: 'MI parser command queue cancelled' });
             // Delete command by key
             delete this.commandQueue[entry[0]];
         });
@@ -66,9 +71,10 @@ export class MIParser {
 
     public queueCommand(
         token: number,
-        command: (resultClass: string, resultData: any) => void
+        command: string,
+        callback: (resultClass: string, resultData: any) => void
     ) {
-        this.commandQueue[token] = command;
+        this.commandQueue[token] = { command, callback };
     }
 
     protected peek() {
@@ -326,13 +332,22 @@ export class MIParser {
                     );
                 }
                 const command = this.commandQueue[token];
+                const resultClass = this.handleString();
+                const resultData = this.handleAsyncData();
+                resultData['cdt-token'] = token;
                 if (command) {
-                    const resultClass = this.handleString();
-                    const resultData = this.handleAsyncData();
-                    command(resultClass, resultData);
+                    resultData['cdt-command'] = command.command;
+                    command.callback(resultClass, resultData);
                     delete this.commandQueue[token];
                 } else {
                     logger.error('GDB response with no command: ' + token);
+                    if (resultClass === 'error') {
+                        this.gdb.emit(
+                            'errorAsync',
+                            resultClass,
+                            resultData
+                        );
+                    }
                 }
                 break;
             }

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -15,7 +15,7 @@ import * as utf8 from 'utf8';
 interface Command {
     command: string;
     callback: (resultClass: string, resultData: any) => void;
-};
+}
 
 type CommandQueue = {
     [key: string]: Command;
@@ -35,7 +35,9 @@ export class MIParser {
         const entries = Object.entries(this.commandQueue);
         entries.forEach((entry) => {
             // Call callback with error to reject command promise
-            entry[1].callback('error', { msg: 'MI parser command queue cancelled' });
+            entry[1].callback('error', {
+                msg: 'MI parser command queue cancelled',
+            });
             // Delete command by key
             delete this.commandQueue[entry[0]];
         });
@@ -350,11 +352,7 @@ export class MIParser {
                         logger.error(message);
                     }
                 }
-                this.gdb.emit(
-                    'resultAsync',
-                    resultClass,
-                    resultData
-                );
+                this.gdb.emit('resultAsync', resultClass, resultData);
                 break;
             }
             case '~':

--- a/src/constants/gdb.ts
+++ b/src/constants/gdb.ts
@@ -1,0 +1,50 @@
+/*********************************************************************
+ * Copyright (c) 2025 Arm Ltd. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+/**
+ * GDB MI and GDB CLI commands considered to cause
+ * a thread/target resume.
+ */
+export const RESUME_COMMANDS = [
+    // GDB MI
+    '-exec-continue',
+    '-exec-finish',
+    '-exec-jump',
+    '-exec-next',
+    '-exec-next-instruction',
+    '-exec-return',
+    '-exec-run',
+    '-exec-step',
+    '-exec-step-instruction',
+    '-exec-until',
+    // GDB CLI (initCommands, customResetCommands)
+    'advance',
+    'continue',
+    'fg',
+    'c',
+    'finish',
+    'fin',
+    'jump',
+    'j',
+    'next',
+    'n',
+    'nexti',
+    'ni',
+    'run',
+    'r',
+    'start',
+    'starti',
+    'step',
+    's',
+    'stepi',
+    'si',
+    'until',
+    'u',
+];

--- a/src/gdb/GDBBackend.ts
+++ b/src/gdb/GDBBackend.ts
@@ -197,34 +197,38 @@ export class GDBBackend extends events.EventEmitter implements IGDBBackend {
                         reject(error);
                     }
                 };
-                this.parser.queueCommand(token, command, (resultClass, resultData) => {
-                    switch (resultClass) {
-                        case 'done':
-                        case 'running':
-                        case 'connected':
-                        case 'exit':
-                            logger.verbose(
-                                `GDB command: ${token} ${command} completed with data`
-                            );
-                            resolve(resultData);
-                            break;
-                        case 'error':
-                            failure.message = resultData.msg;
-                            logger.verbose(
-                                `GDB command: ${token} ${command} failed with '${failure.message}'`
-                            );
-                            reject(failure);
-                            break;
-                        default:
-                            failure.message = `Unknown response ${resultClass}: ${JSON.stringify(
-                                resultData
-                            )}`;
-                            logger.verbose(
-                                `GDB command: ${token} ${command} failed with unknown response '${failure.message}'`
-                            );
-                            reject(failure);
+                this.parser.queueCommand(
+                    token,
+                    command,
+                    (resultClass, resultData) => {
+                        switch (resultClass) {
+                            case 'done':
+                            case 'running':
+                            case 'connected':
+                            case 'exit':
+                                logger.verbose(
+                                    `GDB command: ${token} ${command} completed with data`
+                                );
+                                resolve(resultData);
+                                break;
+                            case 'error':
+                                failure.message = resultData.msg;
+                                logger.verbose(
+                                    `GDB command: ${token} ${command} failed with '${failure.message}'`
+                                );
+                                reject(failure);
+                                break;
+                            default:
+                                failure.message = `Unknown response ${resultClass}: ${JSON.stringify(
+                                    resultData
+                                )}`;
+                                logger.verbose(
+                                    `GDB command: ${token} ${command} failed with unknown response '${failure.message}'`
+                                );
+                                reject(failure);
+                        }
                     }
-                });
+                );
                 logger.verbose(`GDB write command: ${token} ${command}`);
                 // Add callback for this context to set of pending callbacks.
                 // Means to reject pending writes on pipe loss.

--- a/src/gdb/GDBBackend.ts
+++ b/src/gdb/GDBBackend.ts
@@ -197,7 +197,7 @@ export class GDBBackend extends events.EventEmitter implements IGDBBackend {
                         reject(error);
                     }
                 };
-                this.parser.queueCommand(token, (resultClass, resultData) => {
+                this.parser.queueCommand(token, command, (resultClass, resultData) => {
                     switch (resultClass) {
                         case 'done':
                         case 'running':

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -45,18 +45,7 @@ import { calculateMemoryOffset } from '../util/calculateMemoryOffset';
 import { isWindowsPath } from '../util/isWindowsPath';
 import { sendResponseWithTimeout } from '../util/sendResponseWithTimeout';
 import { DEFAULT_STEPPING_RESPONSE_TIMEOUT } from '../constants/session';
-
-class ThreadWithStatus implements DebugProtocol.Thread {
-    id: number;
-    name: string;
-    running: boolean;
-    lastRunToken: string | undefined;
-    constructor(id: number, name: string, running: boolean) {
-        this.id = id;
-        this.name = name;
-        this.running = running;
-    }
-}
+import { ThreadWithStatus } from './common';
 
 /**
  * Keeps track of where in the configuration phase (between initialized event

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2260,6 +2260,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 if (stopAll) {
                     // All threads are stopped
                     this.sendStoppedEvent('error', this.threads[0]?.id ?? 1, true);
+                    this.isRunning = false;
                 } else {
                     // Selection of threas is stopped, send individual events
                     stopThreads.forEach(thread => this.sendStoppedEvent('error', thread.id, false));

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -46,6 +46,7 @@ import { isWindowsPath } from '../util/isWindowsPath';
 import { sendResponseWithTimeout } from '../util/sendResponseWithTimeout';
 import { DEFAULT_STEPPING_RESPONSE_TIMEOUT } from '../constants/session';
 import { ThreadWithStatus } from './common';
+import { RESUME_COMMANDS } from '../constants/gdb';
 
 /**
  * Keeps track of where in the configuration phase (between initialized event
@@ -77,43 +78,6 @@ const cNumberTypeRegex = /\b(?:char|short|int|long|float|double)$/; // match C n
 const cBoolRegex = /\bbool$/; // match boolean
 const threadIdRegex = /.*\s+\-\-thread\s+(\d+).*/;
 const threadAllRegex = /.*\s+\-\-all(\s+.*|$)/;
-
-const resumeCommands = [
-    // GDB MI
-    '-exec-continue',
-    '-exec-finish',
-    '-exec-jump',
-    '-exec-next',
-    '-exec-next-instruction',
-    '-exec-return',
-    '-exec-run',
-    '-exec-step',
-    '-exec-step-instruction',
-    '-exec-until',
-    // GDB CLI (initCommands, customResetCommands)
-    'advance',
-    'continue',
-    'fg',
-    'c',
-    'finish',
-    'fin',
-    'jump',
-    'j',
-    'next',
-    'n',
-    'nexti',
-    'ni',
-    'run',
-    'r',
-    'start',
-    'starti',
-    'step',
-    's',
-    'stepi',
-    'si',
-    'until',
-    'u',
-];
 
 // Interface for output category pair
 interface StreamOutput {
@@ -2250,7 +2214,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         const token = notifyData['cdt-token'];
         const resumeCommand =
             typeof originalCommand === 'string'
-                ? resumeCommands.some(
+                ? RESUME_COMMANDS.some(
                       (cmd) =>
                           originalCommand === cmd ||
                           originalCommand.startsWith(cmd + ' ')

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -353,6 +353,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.gdb.on('notifyAsync', (resultClass, resultData) =>
             this.handleGDBNotify(resultClass, resultData)
         );
+        this.gdb.on('errorAsync', (resultClass, resultData) =>
+            this.handleGDBError(resultClass, resultData)
+        );
     }
 
     protected async attachOrLaunchRequest(
@@ -2208,6 +2211,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     )}`
                 );
         }
+    }
+
+    protected handleGDBError(notifyClass: string, notifyData: any) {    
+        logger.error(`Incoming async error: class - ${notifyClass}, data - ${notifyData}`);
     }
 
     protected async handleVariableRequestFrame(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2284,8 +2284,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         );
                     }
                     updateThreads.forEach(
-                        (thread) =>
-                            (thread.lastRunToken = notifyData['cdt-token'])
+                        (thread) => (thread.lastRunToken = token)
                     );
                 }
                 break;

--- a/src/gdb/common.ts
+++ b/src/gdb/common.ts
@@ -13,6 +13,7 @@ export class ThreadWithStatus implements DebugProtocol.Thread {
     id: number;
     name: string;
     running: boolean;
+    lastRunToken: string | undefined;
     constructor(id: number, name: string, running: boolean) {
         this.id = id;
         this.name = name;

--- a/src/integration-tests/lateAsyncErrorsRemote.spec.ts
+++ b/src/integration-tests/lateAsyncErrorsRemote.spec.ts
@@ -1,0 +1,158 @@
+/*********************************************************************
+ * Copyright (c) 2025 Arm and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as path from 'path';
+import { CdtDebugClient } from './debugClient';
+import {
+    fillDefaults,
+    gdbAsync,
+    isRemoteTest,
+    resolveLineTagLocations,
+    standardBeforeEach,
+    testProgramsDir,
+} from './utils';
+import { TargetLaunchRequestArguments } from '../types/session';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { expect } from 'chai';
+
+describe('lateAsyncErrorsRemote', async function () {
+    let dc: CdtDebugClient;
+    const program = path.join(testProgramsDir, 'loopforever');
+    const src = path.join(testProgramsDir, 'loopforever.c');
+    const lineTags = {
+        'main function': 0,
+        'inner1 stop': 0,
+    };
+
+    this.beforeAll(function () {
+        resolveLineTagLocations(src, lineTags);
+    });
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach('debugTargetAdapter.js');
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program,
+            } as TargetLaunchRequestArguments)
+        );
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    it('should provoke an error and not continue with too many watchpoints, but continue after reducing the number', async function () {
+        if (!isRemoteTest || !gdbAsync) {
+            this.skip();
+        }
+
+        await dc.setBreakpointsRequest({
+            source: { path: src },
+            breakpoints: [{ line: lineTags['main function'] }],
+        });
+
+        // Stopped by default
+        let stoppedEvent: DebugProtocol.StoppedEvent | undefined = undefined;
+        await Promise.all([
+            new Promise<void>(async (resolve) => {
+                stoppedEvent = (await dc.waitForEvent(
+                    'stopped'
+                )) as DebugProtocol.StoppedEvent;
+                resolve();
+            }),
+            dc.configurationDoneRequest(),
+        ]);
+
+        expect(stoppedEvent).to.not.be.undefined;
+        if (!stoppedEvent) {
+            // Pointless to continue test
+            return;
+        }
+
+        // Set too many watchpoints, was not able to set HW breaks (on Windows)
+        const watchExpressions = [
+            '>watch var1',
+            '>watch var2',
+            '>watch stop',
+            '>awatch var1',
+            '>awatch var2',
+            '>awatch stop',
+            '>rwatch var1',
+            '>rwatch var2',
+            '>rwatch stop',
+        ];
+        watchExpressions.forEach(async (expr) => {
+            await dc.evaluateRequest({
+                expression: expr,
+                context: 'repl',
+            });
+        });
+
+        // Set breakpoint to hit next
+        await dc.setBreakpointsRequest({
+            source: { path: src },
+            breakpoints: [{ line: lineTags['inner1 stop'] }],
+        });
+
+        await Promise.all([
+            dc.waitForEvent('continued'), // Continue will cause continued event, error noticed late
+            new Promise<void>(async (resolve) => {
+                // Late error after attempt to install watchpoints, store it
+                stoppedEvent = (await dc.waitForEvent(
+                    'stopped'
+                )) as DebugProtocol.StoppedEvent;
+                resolve();
+            }),
+            dc.waitForOutputEvent(
+                // Proof we had too many breakpoints
+                'log',
+                'You may have requested too many hardware breakpoints/watchpoints.\n'
+            ),
+            dc.continueRequest({
+                threadId:
+                    (stoppedEvent as unknown as DebugProtocol.StoppedEvent).body
+                        .threadId ?? 1,
+            }),
+        ]);
+        expect(stoppedEvent).to.not.be.undefined;
+        if (!stoppedEvent) {
+            // Pointless to continue test
+            return;
+        }
+        // Check expected stop reason
+        expect(
+            (stoppedEvent as DebugProtocol.StoppedEvent).body.reason
+        ).to.equal('error');
+
+        // Remove all breakpoints/watchpoints
+        await dc.evaluateRequest({
+            expression: '>delete breakpoints',
+            context: 'repl',
+        });
+
+        // Check command queue recovered and executes next commands
+        // Reinstall breakpoint to hit next
+        await dc.setBreakpointsRequest({
+            source: { path: src },
+            breakpoints: [{ line: lineTags['inner1 stop'] }],
+        });
+        // Set next breakpoint to hit, run and hit it
+        await Promise.all([
+            dc.assertStoppedLocation('breakpoint', {
+                line: lineTags['inner1 stop'],
+            }),
+            dc.continueRequest({
+                threadId:
+                    (stoppedEvent as unknown as DebugProtocol.StoppedEvent).body
+                        .threadId ?? 1,
+            }),
+        ]);
+    });
+});

--- a/src/integration-tests/miparser.spec.ts
+++ b/src/integration-tests/miparser.spec.ts
@@ -37,14 +37,14 @@ describe('MI Parser Test Suite', function () {
         const callback = sinon.spy();
         parser.queueCommand(5, 'command string', callback);
         parser.parseLine('5^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', {});
+        sinon.assert.calledOnceWithExactly(callback, 'done', { 'cdt-token': '5', 'cdt-command': 'command string' });
     });
 
     it('simple result-record with multi-digit token', async function () {
         const callback = sinon.spy();
         parser.queueCommand(1234, 'command string', callback);
         parser.parseLine('1234^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', {});
+        sinon.assert.calledOnceWithExactly(callback, 'done', { 'cdt-token': '1234', 'cdt-command': 'command string' });
     });
 
     it('simple result-record for unknown token number', async function () {

--- a/src/integration-tests/miparser.spec.ts
+++ b/src/integration-tests/miparser.spec.ts
@@ -37,14 +37,20 @@ describe('MI Parser Test Suite', function () {
         const callback = sinon.spy();
         parser.queueCommand(5, 'command string', callback);
         parser.parseLine('5^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', { 'cdt-token': '5', 'cdt-command': 'command string' });
+        sinon.assert.calledOnceWithExactly(callback, 'done', {
+            'cdt-token': '5',
+            'cdt-command': 'command string',
+        });
     });
 
     it('simple result-record with multi-digit token', async function () {
         const callback = sinon.spy();
         parser.queueCommand(1234, 'command string', callback);
         parser.parseLine('1234^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', { 'cdt-token': '1234', 'cdt-command': 'command string' });
+        sinon.assert.calledOnceWithExactly(callback, 'done', {
+            'cdt-token': '1234',
+            'cdt-command': 'command string',
+        });
     });
 
     it('simple result-record for unknown token number', async function () {

--- a/src/integration-tests/miparser.spec.ts
+++ b/src/integration-tests/miparser.spec.ts
@@ -35,14 +35,14 @@ describe('MI Parser Test Suite', function () {
 
     it('simple result-record', async function () {
         const callback = sinon.spy();
-        parser.queueCommand(5, callback);
+        parser.queueCommand(5, 'command string', callback);
         parser.parseLine('5^done');
         sinon.assert.calledOnceWithExactly(callback, 'done', {});
     });
 
     it('simple result-record with multi-digit token', async function () {
         const callback = sinon.spy();
-        parser.queueCommand(1234, callback);
+        parser.queueCommand(1234, 'command string', callback);
         parser.parseLine('1234^done');
         sinon.assert.calledOnceWithExactly(callback, 'done', {});
     });

--- a/src/integration-tests/miparser.spec.ts
+++ b/src/integration-tests/miparser.spec.ts
@@ -12,15 +12,20 @@ import { GDBBackend } from '../gdb/GDBBackend';
 import { MIParser } from '../MIParser';
 import * as sinon from 'sinon';
 import { logger } from '@vscode/debugadapter/lib/logger';
+import { expect } from 'chai';
 
 describe('MI Parser Test Suite', function () {
     let gdbBackendMock: sinon.SinonStubbedInstance<GDBBackend>;
     let loggerErrorSpy: sinon.SinonSpy;
+    let loggerVerboseSpy: sinon.SinonSpy;
+    let callback: sinon.SinonSpy;
     let parser: MIParser;
 
     beforeEach(async function () {
         gdbBackendMock = sinon.createStubInstance(GDBBackend);
         loggerErrorSpy = sinon.spy(logger, 'error');
+        loggerVerboseSpy = sinon.spy(logger, 'verbose');
+        callback = sinon.spy();
 
         parser = new MIParser(gdbBackendMock);
     });
@@ -30,24 +35,113 @@ describe('MI Parser Test Suite', function () {
             sinon.assert.notCalled(loggerErrorSpy);
         } finally {
             sinon.restore();
+            sinon.resetHistory();
         }
     });
 
+    const resetSpyHistories = () => {
+        callback.resetHistory();
+        loggerVerboseSpy.resetHistory();
+        loggerErrorSpy.resetHistory();
+        gdbBackendMock.emit.resetHistory();
+    };
+
+    const assertCallbackAndEmitResultAsync = (
+        resultClass: string,
+        resultData: any
+    ) => {
+        sinon.assert.calledOnceWithExactly(callback, resultClass, resultData);
+        sinon.assert.calledOnceWithExactly(
+            gdbBackendMock.emit as sinon.SinonStub,
+            'resultAsync',
+            resultClass,
+            resultData
+        );
+    };
+
+    const assertNoCallbackButEmitResultAsync = (
+        resultClass: string,
+        resultData: any
+    ) => {
+        sinon.assert.notCalled(callback);
+        sinon.assert.calledOnceWithExactly(
+            gdbBackendMock.emit as sinon.SinonStub,
+            'resultAsync',
+            resultClass,
+            resultData
+        );
+    };
+
+    type LogBehavior = 'verbose' | 'error' | 'both' | 'none';
+    const assertNoCommandTokenLog = (
+        token: string,
+        logBehavior: LogBehavior
+    ) => {
+        switch (logBehavior) {
+            case 'verbose':
+                expect(
+                    loggerVerboseSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.true;
+                expect(
+                    loggerErrorSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.false;
+                break;
+            case 'error':
+                expect(
+                    loggerVerboseSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.false;
+                expect(
+                    loggerErrorSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.true;
+                break;
+            case 'both':
+                expect(
+                    loggerVerboseSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.true;
+                expect(
+                    loggerErrorSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.true;
+                break;
+            case 'none':
+                expect(
+                    loggerVerboseSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.false;
+                expect(
+                    loggerErrorSpy.calledWithExactly(
+                        `GDB response with no command: ${token}`
+                    )
+                ).to.be.false;
+                break;
+        }
+    };
+
     it('simple result-record', async function () {
-        const callback = sinon.spy();
         parser.queueCommand(5, 'command string', callback);
         parser.parseLine('5^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', {
+        assertCallbackAndEmitResultAsync('done', {
             'cdt-token': '5',
             'cdt-command': 'command string',
         });
     });
 
     it('simple result-record with multi-digit token', async function () {
-        const callback = sinon.spy();
         parser.queueCommand(1234, 'command string', callback);
         parser.parseLine('1234^done');
-        sinon.assert.calledOnceWithExactly(callback, 'done', {
+        assertCallbackAndEmitResultAsync('done', {
             'cdt-token': '1234',
             'cdt-command': 'command string',
         });
@@ -59,6 +153,11 @@ describe('MI Parser Test Suite', function () {
             loggerErrorSpy,
             'GDB response with no command: 5'
         );
+        expect(
+            gdbBackendMock.emit.calledOnceWithExactly('resultAsync', 'done', {
+                'cdt-token': '5',
+            })
+        ).to.be.true;
         loggerErrorSpy.resetHistory();
     });
 
@@ -68,6 +167,11 @@ describe('MI Parser Test Suite', function () {
             loggerErrorSpy,
             'GDB response with no command: '
         );
+        expect(
+            gdbBackendMock.emit.calledOnceWithExactly('resultAsync', 'done', {
+                'cdt-token': '',
+            })
+        ).to.be.true;
         loggerErrorSpy.resetHistory();
     });
 
@@ -178,5 +282,98 @@ describe('MI Parser Test Suite', function () {
                 },
             }
         );
+    });
+
+    it('correctly handles error result for a command', async function () {
+        // Command
+        parser.queueCommand(5, '-exec-continue --thread 8', callback);
+        // Error result
+        parser.parseLine('5^error,msg="Command aborted"');
+        assertCallbackAndEmitResultAsync('error', {
+            'cdt-token': '5',
+            'cdt-command': '-exec-continue --thread 8',
+            msg: 'Command aborted',
+        });
+        assertNoCommandTokenLog('5', 'none');
+    });
+
+    it('correctly handles late arrival error after done result for command', async function () {
+        // Command
+        parser.queueCommand(5, '-exec-continue --thread 8', callback);
+        // Done result
+        parser.parseLine('5^done');
+        assertCallbackAndEmitResultAsync('done', {
+            'cdt-token': '5',
+            'cdt-command': '-exec-continue --thread 8',
+        });
+        assertNoCommandTokenLog('5', 'none');
+        resetSpyHistories();
+        // Late arrival error response for same command
+        parser.parseLine('5^error,msg="any error"');
+        assertNoCallbackButEmitResultAsync('error', {
+            'cdt-token': '5',
+            msg: 'any error',
+        });
+        assertNoCommandTokenLog('5', 'verbose');
+    });
+
+    it('correctly handles unrelated done result between command and its done result', async function () {
+        // Command
+        parser.queueCommand(5, '-exec-continue --thread 8', callback);
+        // Unrelated result without command in queue
+        parser.parseLine('6^done');
+        assertNoCallbackButEmitResultAsync('done', {
+            'cdt-token': '6',
+        });
+        assertNoCommandTokenLog('6', 'error');
+        resetSpyHistories();
+        // Done result for command
+        parser.parseLine('5^done');
+        assertCallbackAndEmitResultAsync('done', {
+            'cdt-token': '5',
+            'cdt-command': '-exec-continue --thread 8',
+        });
+        assertNoCommandTokenLog('5', 'none');
+    });
+
+    it('correctly handles unrelated done result between command and its error result', async function () {
+        // Command
+        parser.queueCommand(5, '-exec-continue --thread 8', callback);
+        // Unrelated result without command in queue
+        parser.parseLine('6^done');
+        assertNoCallbackButEmitResultAsync('done', {
+            'cdt-token': '6',
+        });
+        assertNoCommandTokenLog('6', 'error');
+        resetSpyHistories();
+        // Done result for command
+        parser.parseLine('5^error,msg="failed"');
+        assertCallbackAndEmitResultAsync('error', {
+            'cdt-token': '5',
+            'cdt-command': '-exec-continue --thread 8',
+            msg: 'failed',
+        });
+        assertNoCommandTokenLog('5', 'none');
+    });
+
+    it('correctly handles unrelated error result between command and its error result', async function () {
+        // Command
+        parser.queueCommand(5, '-exec-continue --thread 8', callback);
+        // Unrelated error result without command in queue
+        parser.parseLine('6^error,msg="one error"');
+        assertNoCallbackButEmitResultAsync('error', {
+            'cdt-token': '6',
+            msg: 'one error',
+        });
+        assertNoCommandTokenLog('6', 'verbose');
+        resetSpyHistories();
+        // Error result for command
+        parser.parseLine('5^error,msg="another error"');
+        assertCallbackAndEmitResultAsync('error', {
+            'cdt-token': '5',
+            'cdt-command': '-exec-continue --thread 8',
+            msg: 'another error',
+        });
+        assertNoCommandTokenLog('5', 'none');
     });
 });

--- a/src/integration-tests/test-programs/loopforever.c
+++ b/src/integration-tests/test-programs/loopforever.c
@@ -14,7 +14,7 @@ int inner2(void) {
 
 int main(int argc, char *argv[])
 {
-    time_t start_time = time(NULL);
+    time_t start_time = time(NULL);  // main function
     while (stop == 0) {
         if (time(NULL) > start_time + 10) {
             // Don't actually loop forever as that can hang tests
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
             // especially on Windows where pause does not work (yet)
             return 1;
         }
-        inner1();
+        inner1();  // inner1 stop
         inner2();
     }
     return 0;

--- a/src/types/gdb.ts
+++ b/src/types/gdb.ts
@@ -141,7 +141,7 @@ export interface IGDBBackend extends EventEmitter {
         listener: (output: string, category: string) => void
     ): this;
     on(
-        event: 'execAsync' | 'notifyAsync' | 'statusAsync',
+        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'errorAsync',
         listener: (asyncClass: string, data: any) => void
     ): this;
     on(
@@ -155,7 +155,7 @@ export interface IGDBBackend extends EventEmitter {
         category: string
     ): boolean;
     emit(
-        event: 'execAsync' | 'notifyAsync' | 'statusAsync',
+        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'errorAsync',
         asyncClass: string,
         data: any
     ): boolean;

--- a/src/types/gdb.ts
+++ b/src/types/gdb.ts
@@ -141,7 +141,7 @@ export interface IGDBBackend extends EventEmitter {
         listener: (output: string, category: string) => void
     ): this;
     on(
-        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'errorAsync',
+        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'resultAsync',
         listener: (asyncClass: string, data: any) => void
     ): this;
     on(
@@ -155,7 +155,7 @@ export interface IGDBBackend extends EventEmitter {
         category: string
     ): boolean;
     emit(
-        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'errorAsync',
+        event: 'execAsync' | 'notifyAsync' | 'statusAsync' | 'resultAsync',
         asyncClass: string,
         data: any
     ): boolean;


### PR DESCRIPTION
Address #402 , but actually goes beyond to fix the root cause.

Problem: If you set too many breakpoints
* gdb may report a completed (e.g.) `continue` command as `running`/`done`.
* gdb/gdbserver may install breakpoints and start running.
* Along the way, gdbserver may reject adding breakpoints if not enough HW resource is available.
* gdb may send a late `error` response referring to the previously successfully completed `continue` command.

Before this change, this could heavily confuse the adapter states and provoke funny behavior.

This PR changes this to recover from such situations. It
* stores additional, artificial information with the MI result data in the MI parser, prefixed with `cdt-` to avoid confusion with real MI payload
  * 'cdt-token': token of a command
  * 'cdt-command': original command string of a completing command that is still in the queue.
* Changes the MI parser command queue to add this data.
* Adds a `resultAsync` event between MI parser and session classes sending GDB async results. 'cdt-command' is only added for the first result for a token.
* Extends the thread state to include the token of the last command setting it running. (Cleared on stopped notifications)
  * Handle `done`/`running` results of successful commands that resume the target (sorry about that list of potential commands, I know it's ugly). Store their token per thread.
  * Handle `error` results for commands with tokens stored in the thread states. These are the out-of-band errors and require returning internal and VS Code thread states to stopped.


Note: Still a draft as I need to add a few pinpointed tests.