### PR TITLE
Disabling evaluate request error messages when hovering over comments

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1541,7 +1541,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         } catch (err) {
             if (
                 err instanceof Error &&
-                err.message === '-var-create: unable to create variable object'
+                err.message.includes('var-create')
             ) {
                 if (args.context === 'hover') {
                     response.success = false;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1539,10 +1539,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            if (
-                err instanceof Error &&
-                err.message.includes('var-create')
-            ) {
+            if (err instanceof Error && err.message.includes('var-create')) {
                 if (args.context === 'hover') {
                     response.success = false;
                 }


### PR DESCRIPTION
When hovering over comments in code, vscode sends an evaluateRequest to the adapter, which in turn sends it to GDB. This causes an unnecessary popping error message to users all the time.

I disabled the error message only when hovering