### PR TITLE
Covering the case when source file for Breakpoint is unknown

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2021,7 +2021,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     if (notifyData.bkpt.disp === 'del') {
                         break;
                     }
-                    const breakpoint: DebugProtocol.Breakpoint = {
+                    let breakpoint : DebugProtocol.Breakpoint;
+                    if (notifyData.bkpt.line) {
+                        breakpoint = {
                         id: parseInt(notifyData.bkpt.number, 10),
                         verified: true,
                         source: {
@@ -2029,7 +2031,15 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             path: notifyData.bkpt.file,
                         },
                         line: parseInt(notifyData.bkpt.line, 10),
-                    };
+                        };
+                    } else {
+                        breakpoint = {
+                        id: parseInt(notifyData.bkpt.number, 10),
+                        verified: true,
+                        instructionReference: notifyData.bkpt.addr,
+                        };
+                    }
+                    
                     const breakpointevent = new BreakpointEvent(
                         'changed',
                         breakpoint

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2022,7 +2022,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         break;
                     }
                     let breakpoint : DebugProtocol.Breakpoint;
-                    if (notifyData.bkpt.line) {
+                    if (notifyData.bkpt.file) {
                         breakpoint = {
                         id: parseInt(notifyData.bkpt.number, 10),
                         verified: true,


### PR DESCRIPTION
Background:

When debugging, sometimes the debugger won't know the source file in which a breakpoint is set. Accordingly when the adapter gets a notification that is associated with such a breakpoint, it would try to set the value of `source` and `line` in the breakpoint interface to be sent in a breakpoint event. This is a faulty behaviour and it causes problems in the breakpoints window in the IDE.

Changes:

Now whenever the adapter receives a GDB notification for a modified and unknown BP, it will look first if the source information is provided, if not, then it won't use it