### PR TITLE
Improvement for step functions latencies

### DIFF
--- a/src/constants/session.ts
+++ b/src/constants/session.ts
@@ -1,0 +1,15 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+/**
+ * The default stepping response timeout.
+ * Used if it is not defined in the launch configuration.
+ */
+export const DEFAULT_STEPPING_RESPONSE_TIMEOUT = 100;

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -169,7 +169,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         args: TargetLaunchRequestArguments | TargetAttachRequestArguments
     ) {
         await this.setupCommonLoggerAndBackends(args);
-        this.initializeCustomResetCommands(args);
+        this.initializeSessionArguments(args);
 
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;

--- a/src/integration-tests/sendResponseWithTimeout.spec.ts
+++ b/src/integration-tests/sendResponseWithTimeout.spec.ts
@@ -1,0 +1,401 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { sendResponseWithTimeout } from '../util/sendResponseWithTimeout';
+
+describe('sendResponseWithTimeout', function () {
+    const defaultTimeout = 100;
+    const testError = new Error('Test execution error');
+
+    let sandbox: sinon.SinonSandbox;
+    let clock: sinon.SinonFakeTimers;
+    let executeStub: sinon.SinonStub;
+    let onResponseStub: sinon.SinonStub;
+    let onErrorStub: sinon.SinonStub;
+    type VoidResolve = () => void;
+    let executeResolve: VoidResolve;
+    let executeRejects: (reason: any) => void;
+    let executePromise: Promise<void>;
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+        clock = sandbox.useFakeTimers();
+        executeStub = sandbox.stub();
+        onResponseStub = sandbox.stub();
+        onErrorStub = sandbox.stub();
+
+        executePromise = new Promise<void>((resolve, rejects) => {
+            executeResolve = resolve;
+            executeRejects = rejects;
+        });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('Normal execution scenarios', function () {
+        it('should execute and call onResponse immediately when execute completes before timeout', async function () {
+            executeStub.resolves();
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: defaultTimeout,
+            });
+
+            clock.tick(50);
+            await promise;
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+            expect(onErrorStub.notCalled).to.be.true;
+        });
+
+        it('should call onResponse via timeout when execute takes longer than timeout', async function () {
+            executeStub.returns(executePromise);
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: defaultTimeout,
+            });
+
+            clock.tick(25);
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.notCalled).to.be.true;
+
+            // Just 1ms after the timeout.
+            clock.tick(defaultTimeout - 25 + 1);
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+
+            executeResolve();
+            await promise;
+
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should not call onResponse twice when execute completes just after timeout', async function () {
+            executeStub.returns(executePromise);
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: defaultTimeout,
+            });
+
+            clock.tick(defaultTimeout);
+
+            expect(onResponseStub.calledOnce).to.be.true;
+
+            executeResolve();
+            await promise;
+
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should work with synchronous execute function', async function () {
+            executeStub.returns(undefined);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should work with synchronous onResponse function', async function () {
+            executeStub.resolves();
+            onResponseStub.returns(undefined);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should handle concurrent calls independently', async function () {
+            const executeStub1 = sandbox.stub().resolves();
+            const onResponseStub1 = sandbox.stub().resolves();
+            const executeStub2 = sandbox.stub();
+            const onResponseStub2 = sandbox.stub().resolves();
+
+            executeStub2.returns(executePromise);
+
+            const promise1 = sendResponseWithTimeout({
+                execute: executeStub1,
+                onResponse: onResponseStub1,
+                timeout: 50,
+            });
+
+            const promise2 = sendResponseWithTimeout({
+                execute: executeStub2,
+                onResponse: onResponseStub2,
+                timeout: defaultTimeout,
+            });
+
+            await promise1;
+            expect(onResponseStub1.calledOnce).to.be.true;
+
+            clock.tick(defaultTimeout);
+            expect(onResponseStub2.calledOnce).to.be.true;
+
+            executeResolve();
+            await promise2;
+
+            expect(onResponseStub1.calledOnce).to.be.true;
+            expect(onResponseStub2.calledOnce).to.be.true;
+        });
+    });
+
+    describe('Error handling scenarios', function () {
+        it('should call onError when execute throws an error and onError is provided', async function () {
+            executeStub.rejects(testError);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                onError: onErrorStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onErrorStub.calledOnceWith(testError)).to.be.true;
+            expect(onResponseStub.notCalled).to.be.true;
+        });
+
+        it('should rethrow error when execute throws and onError is not provided', async function () {
+            executeStub.rejects(testError);
+
+            try {
+                await sendResponseWithTimeout({
+                    execute: executeStub,
+                    onResponse: onResponseStub,
+                    timeout: defaultTimeout,
+                });
+                expect.fail('Should have thrown an error');
+            } catch (error) {
+                expect(error).to.equal(testError);
+            }
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.notCalled).to.be.true;
+        });
+
+        it('should handle synchronous errors from execute', async function () {
+            executeStub.throws(testError);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                onError: onErrorStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onErrorStub.calledOnceWith(testError)).to.be.true;
+            expect(onResponseStub.notCalled).to.be.true;
+        });
+
+        it('should handle errors in onError function gracefully', async function () {
+            const executeError = new Error('Execute error');
+            const onErrorError = new Error('OnError error');
+            executeStub.rejects(executeError);
+            onErrorStub.rejects(onErrorError);
+
+            try {
+                await sendResponseWithTimeout({
+                    execute: executeStub,
+                    onResponse: onResponseStub,
+                    onError: onErrorStub,
+                    timeout: defaultTimeout,
+                });
+                expect.fail('Should have thrown the onError error');
+            } catch (error) {
+                expect(error).to.equal(onErrorError);
+            }
+        });
+
+        it('should call onError when onResponse throws an error and onError is provided', async function () {
+            executeStub.resolves();
+            onResponseStub.rejects(testError);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                onError: onErrorStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onErrorStub.calledOnceWith(testError)).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should call onError when onResponse throws an error and onError is not provided', async function () {
+            executeStub.resolves();
+            onResponseStub.rejects(testError);
+
+            try {
+                await sendResponseWithTimeout({
+                    execute: executeStub,
+                    onResponse: onResponseStub,
+                    timeout: defaultTimeout,
+                });
+                expect.fail('Should have thrown the onResponse error');
+            } catch (error) {
+                expect(error).to.equal(testError);
+            }
+        });
+    });
+
+    describe('Timeout behavior', function () {
+        it('should handle different timeout values', async function () {
+            executeStub.returns(executePromise);
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: 50,
+            });
+
+            clock.tick(25);
+            expect(onResponseStub.notCalled).to.be.true;
+
+            clock.tick(25);
+            expect(onResponseStub.calledOnce).to.be.true;
+
+            executeResolve();
+            await promise;
+        });
+
+        it('should handle zero timeout', async function () {
+            executeStub.returns(executePromise);
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: 0,
+            });
+
+            clock.tick(1);
+
+            expect(onResponseStub.calledOnce).to.be.true;
+
+            executeResolve();
+            await promise;
+        });
+
+        it('should clear timeout when execute completes before timeout', async function () {
+            executeStub.resolves();
+            const clearTimeoutSpy = sandbox.spy(global, 'clearTimeout');
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: 1000,
+            });
+
+            expect(clearTimeoutSpy.called).to.be.true;
+        });
+
+        it('should disable timeout when negative timeout is provided', async function () {
+            executeStub.returns(executePromise);
+            const setTimeoutSpy = sandbox.spy(global, 'setTimeout');
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: -1,
+            });
+
+            // Advance time significantly
+            clock.tick(10000);
+
+            expect(onResponseStub.notCalled).to.be.true;
+            expect(setTimeoutSpy.notCalled).to.be.true;
+
+            executeResolve();
+            await promise;
+
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+
+        it('should handle negative timeout with immediate execution', async function () {
+            executeStub.resolves();
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                timeout: -100,
+            });
+
+            expect(executeStub.calledOnce).to.be.true;
+            expect(onResponseStub.calledOnce).to.be.true;
+        });
+    });
+
+    describe('hasResponseSent parameter in onError', function () {
+        it('should pass hasResponseSent=false when error occurs before timeout', async function () {
+            executeStub.rejects(testError);
+
+            await sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                onError: onErrorStub,
+                timeout: defaultTimeout,
+            });
+
+            expect(onErrorStub.calledOnce).to.be.true;
+            expect(onErrorStub.firstCall.args).to.deep.equal([
+                testError,
+                {
+                    hasResponseSent: false,
+                },
+            ]);
+        });
+
+        it('should pass hasResponseSent=true when error occurs after timeout response', async function () {
+            executeStub.returns(executePromise);
+
+            const promise = sendResponseWithTimeout({
+                execute: executeStub,
+                onResponse: onResponseStub,
+                onError: onErrorStub,
+                timeout: defaultTimeout,
+            });
+
+            clock.tick(defaultTimeout);
+            expect(onResponseStub.calledOnce).to.be.true;
+
+            executeRejects(testError);
+            await promise;
+
+            expect(onErrorStub.calledOnce).to.be.true;
+            expect(onErrorStub.firstCall.args).to.deep.equal([
+                testError,
+                {
+                    hasResponseSent: true,
+                },
+            ]);
+        });
+    });
+});

--- a/src/integration-tests/step-functions-unit.spec.ts
+++ b/src/integration-tests/step-functions-unit.spec.ts
@@ -1,0 +1,330 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import * as sendResponseWithTimeoutModule from '../util/sendResponseWithTimeout';
+import { GDBDebugSessionBase } from '../gdb/GDBDebugSessionBase';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { IGDBBackendFactory } from '../types/gdb';
+import { OutputEvent } from '@vscode/debugadapter';
+import * as mi from '../mi/exec';
+import {
+    AttachRequestArguments,
+    LaunchRequestArguments,
+} from '../types/session';
+
+// Test class that extends GDBDebugSessionBase to access protected methods
+class TestGDBSession extends GDBDebugSessionBase {
+    public gdb: any;
+    public sendErrorResponseStub: sinon.SinonStub;
+    public sendResponseStub: sinon.SinonStub;
+    public sendEventStub: sinon.SinonStub;
+
+    constructor(sandbox: sinon.SinonSandbox) {
+        const mockFactory: IGDBBackendFactory = {} as any;
+        super(mockFactory);
+        this.gdb = {};
+
+        this.sendResponseStub = sandbox.stub();
+        this.sendResponse = this.sendResponseStub;
+
+        this.sendErrorResponseStub = sandbox.stub();
+        this.sendErrorResponse = this.sendErrorResponseStub;
+
+        this.sendEventStub = sandbox.stub();
+        this.sendEvent = this.sendEventStub;
+    }
+
+    // Make protected methods public for testing
+    public async testStepInRequest(
+        response: DebugProtocol.StepInResponse,
+        args: DebugProtocol.StepInArguments
+    ) {
+        return this.stepInRequest(response, args);
+    }
+
+    public async testStepOutRequest(
+        response: DebugProtocol.StepOutResponse,
+        args: DebugProtocol.StepOutArguments
+    ) {
+        return this.stepOutRequest(response, args);
+    }
+
+    public async testNextRequest(
+        response: DebugProtocol.NextResponse,
+        args: DebugProtocol.NextArguments
+    ) {
+        return this.nextRequest(response, args);
+    }
+
+    public setSteppingResponseTimeout(timeout?: number) {
+        this.initializeSessionArguments({
+            steppingResponseTimeout: timeout,
+        } as LaunchRequestArguments | AttachRequestArguments);
+    }
+}
+
+describe('Step Functions Unit Tests', function () {
+    let sandbox: sinon.SinonSandbox;
+    let session: TestGDBSession;
+    let sendExecStepStub: sinon.SinonStub;
+    let sendExecStepInstructionStub: sinon.SinonStub;
+    let sendExecFinishStub: sinon.SinonStub;
+    let sendExecNextStub: sinon.SinonStub;
+    let sendExecNextInstructionStub: sinon.SinonStub;
+    let sendResponseWithTimeoutSpy: sinon.SinonSpy;
+
+    const testError = new Error('Test error');
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+        session = new TestGDBSession(sandbox);
+
+        sendResponseWithTimeoutSpy = sandbox.spy(
+            sendResponseWithTimeoutModule,
+            'sendResponseWithTimeout'
+        );
+        sendExecStepStub = sandbox.stub(mi, 'sendExecStep').resolves();
+        sendExecStepInstructionStub = sandbox
+            .stub(mi, 'sendExecStepInstruction')
+            .resolves();
+        sendExecFinishStub = sandbox.stub(mi, 'sendExecFinish').resolves();
+        sendExecNextStub = sandbox.stub(mi, 'sendExecNext').resolves();
+        sendExecNextInstructionStub = sandbox
+            .stub(mi, 'sendExecNextInstruction')
+            .resolves();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    const verifySendResponseWithTimeoutSpyCall = (expectedTimeout = 100) => {
+        expect(sendResponseWithTimeoutSpy.calledOnce).to.be.true;
+        const callArgs = sendResponseWithTimeoutSpy.getCall(0).args[0];
+        expect(callArgs).to.have.property('execute');
+        expect(callArgs).to.have.property('onResponse');
+        expect(callArgs).to.have.property('onError');
+        expect(callArgs).to.have.property('timeout', expectedTimeout);
+    };
+
+    const verifyErrorHandling = (
+        response: DebugProtocol.Response,
+        request: string
+    ) => {
+        expect(
+            session.sendErrorResponseStub.calledOnceWith(
+                response,
+                1,
+                testError.message
+            )
+        ).to.be.true;
+
+        expect(session.sendEventStub.calledOnce).to.be.true;
+        const event = session.sendEventStub.firstCall.args[0];
+        expect(event).to.be.instanceOf(OutputEvent);
+        expect(event.body.output).to.contain(
+            `Error occurred during the ${request}`
+        );
+        expect(event.body.output).to.contain(testError.message);
+        expect(event.body.category).to.equal('console');
+    };
+
+    it('stepInRequest should call sendResponseWithTimeout with correct parameters', async function () {
+        const response = {} as DebugProtocol.StepInResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.StepInArguments;
+
+        await session.testStepInRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+
+        expect(sendExecStepStub.calledOnceWith(session.gdb, 1)).to.be.true;
+        expect(session.sendResponseStub.calledOnceWith(response)).to.be.true;
+    });
+
+    it('stepInRequest with instruction granularity should call sendExecStepInstruction', async function () {
+        const response = {} as DebugProtocol.StepInResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'instruction',
+        } as DebugProtocol.StepInArguments;
+
+        await session.testStepInRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+        expect(sendExecStepInstructionStub.calledOnceWith(session.gdb, 1)).to.be
+            .true;
+        expect(session.sendResponseStub.calledOnceWith(response)).to.be.true;
+    });
+
+    it('stepInRequest should handle errors through sendResponseWithTimeout', async function () {
+        const response = {} as DebugProtocol.StepInResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.StepInArguments;
+
+        sendExecStepStub.rejects(testError);
+
+        await session.testStepInRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+
+        verifyErrorHandling(response, 'stepInRequest');
+    });
+
+    it('stepOutRequest should call sendResponseWithTimeout with correct parameters', async function () {
+        const response = {} as DebugProtocol.StepOutResponse;
+        const args = { threadId: 1 } as DebugProtocol.StepOutArguments;
+
+        await session.testStepOutRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+        expect(
+            sendExecFinishStub.calledOnceWith(session.gdb, {
+                threadId: 1,
+                frameId: 0,
+            })
+        ).to.be.true;
+        expect(session.sendResponseStub.calledOnceWith(response)).to.be.true;
+    });
+
+    it('stepOutRequest should handle errors through sendResponseWithTimeout', async function () {
+        const response = {} as DebugProtocol.StepOutResponse;
+        const args = { threadId: 1 } as DebugProtocol.StepOutArguments;
+        const testError = new Error('Test error');
+        sendExecFinishStub.rejects(testError);
+
+        await session.testStepOutRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+
+        verifyErrorHandling(response, 'stepOutRequest');
+    });
+
+    it('nextRequest should call sendResponseWithTimeout with correct parameters', async function () {
+        const response = {} as DebugProtocol.NextResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.NextArguments;
+
+        await session.testNextRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+        expect(sendExecNextStub.calledOnceWith(session.gdb, 1)).to.be.true;
+        expect(session.sendResponseStub.calledOnceWith(response)).to.be.true;
+    });
+
+    it('nextRequest with instruction granularity should call sendExecNextInstruction', async function () {
+        const response = {} as DebugProtocol.NextResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'instruction',
+        } as DebugProtocol.NextArguments;
+
+        await session.testNextRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+        expect(sendExecNextInstructionStub.calledOnceWith(session.gdb, 1)).to.be
+            .true;
+        expect(session.sendResponseStub.calledOnceWith(response)).to.be.true;
+    });
+
+    it('nextRequest should handle errors through sendResponseWithTimeout', async function () {
+        const response = {} as DebugProtocol.NextResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.NextArguments;
+        const testError = new Error('Test error');
+        sendExecNextStub.rejects(testError);
+
+        await session.testNextRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall();
+
+        verifyErrorHandling(response, 'nextRequest');
+    });
+
+    it('should use custom steppingResponseTimeout for stepInRequest', async function () {
+        const customTimeout = 5000;
+        session.setSteppingResponseTimeout(customTimeout);
+
+        const response = {} as DebugProtocol.StepInResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.StepInArguments;
+
+        await session.testStepInRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall(customTimeout);
+    });
+
+    it('should use custom steppingResponseTimeout for stepOutRequest', async function () {
+        const customTimeout = 3000;
+        session.setSteppingResponseTimeout(customTimeout);
+
+        const response = {} as DebugProtocol.StepOutResponse;
+        const args = { threadId: 1 } as DebugProtocol.StepOutArguments;
+
+        await session.testStepOutRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall(customTimeout);
+    });
+
+    it('should use custom steppingResponseTimeout for nextRequest', async function () {
+        const customTimeout = 8000;
+        session.setSteppingResponseTimeout(customTimeout);
+
+        const response = {} as DebugProtocol.NextResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.NextArguments;
+
+        await session.testNextRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall(customTimeout);
+    });
+
+    it('should default to 100ms timeout when steppingResponseTimeout is undefined', async function () {
+        session.setSteppingResponseTimeout(undefined);
+
+        const response = {} as DebugProtocol.StepInResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'statement',
+        } as DebugProtocol.StepInArguments;
+
+        await session.testStepInRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall(100);
+    });
+
+    it('should handle zero timeout value', async function () {
+        session.setSteppingResponseTimeout(0);
+
+        const response = {} as DebugProtocol.NextResponse;
+        const args = {
+            threadId: 1,
+            granularity: 'instruction',
+        } as DebugProtocol.NextArguments;
+
+        await session.testNextRequest(response, args);
+
+        verifySendResponseWithTimeoutSpyCall(0);
+    });
+});

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -26,6 +26,7 @@ export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     initCommands?: string[];
     hardwareBreakpoint?: boolean;
     customResetCommands?: string[];
+    steppingResponseTimeout?: number;
 }
 
 export interface LaunchRequestArguments extends RequestArguments {

--- a/src/util/sendResponseWithTimeout.ts
+++ b/src/util/sendResponseWithTimeout.ts
@@ -1,0 +1,63 @@
+/*********************************************************************
+ * Copyright (c) 2025 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+export interface SendResponseWithTimeoutParameters {
+    /** The main function to be called during the execution */
+    execute: () => Promise<void> | void;
+    /** The independent response which should be sent after the operation or the timeout */
+    onResponse: () => Promise<void> | void;
+    /** Error handling block. It is optional, if it is not implemented the error will not be catch be thrown */
+    onError?: (
+        error: unknown,
+        args: { hasResponseSent: boolean }
+    ) => Promise<void> | void;
+    /** Timeout to send the response in milliseconds, timer disabled if timeout is negative (e.g. `-1`) */
+    timeout: number;
+}
+
+/**
+ * `sendResponseWithTimeout` method is handling an early response invocation for independent response and execution
+ *  logics after the defined timeout duration, in order to provide the response to the IDE user interface.
+ *  Designed to be used in the debug session operations such as step-in, step-out, step-over.
+ *
+ *  @param parameters Should be specified in `SendResponseWithTimeoutParameters` structure. Provide the
+ * `execute`, `onResponse`, `onError` and `timeout` values.
+ */
+export const sendResponseWithTimeout = async (
+    parameters: SendResponseWithTimeoutParameters
+) => {
+    const { execute, onResponse, onError, timeout } = parameters;
+    let responseSent = false;
+    const timer =
+        timeout >= 0
+            ? setTimeout(async () => {
+                  responseSent = true;
+                  await onResponse();
+              }, timeout)
+            : undefined;
+    try {
+        await execute();
+        clearTimeout(timer);
+        if (!responseSent) {
+            await onResponse();
+        }
+    } catch (err) {
+        // Important to clear timeout if error catched from the `execute` logic.
+        // But it is also safe to call clearTimeout twice if error thrown in the `onResponse` logic.
+        clearTimeout(timer);
+
+        if (!onError) {
+            throw err;
+        }
+        await onError(err, {
+            hasResponseSent: responseSent,
+        });
+    }
+};

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -154,7 +154,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         args: TargetLaunchRequestArguments | TargetAttachRequestArguments
     ) {
         await this.setupCommonLoggerAndBackends(args);
-        this.initializeCustomResetCommands(args);
+        this.initializeSessionArguments(args);
 
         if (request === 'launch') {
             const launchArgs = args as TargetLaunchRequestArguments;


### PR DESCRIPTION
This pull request is related to issue reported in the ticket #428 

In this implementation, a timeouted response is returned to the user interface to change the UI state properly. For this purpose, we implemented:
    
- A new utility function called `sendResponseWithTimeout` to handle the operation.
- Improved the `nextRequest`, `stepInRequest` and `stepOutRequest` methods to introduce the timeouted response, with a default of 100ms timeout.
- Introduce a new launch variable called `steppingResponseTimeout` to provide an option that user can change the default timeout for stepping functions.

Additionally, in the unit tests, in `step-functions-unit.spec.ts` we need to introduce a test with direct class access since the common testing strategies cannot handle to test the internal implementation details of the functions and control whether they are triggered via the `sendResponseWithTimeout` method.
