### PR TITLE
Fix detach getting stuck on exited program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixes [`#437`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/437): `detach` request getting stuck on exited program.
 - Fixes [`#407`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/407): Getting stuck on concurrent breakpoint setup on targets that don’t stop on attach.
 - Fixes [`#427`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/427): Breakpoint source code reference to module disappears when breakpoint is hit
 

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -63,12 +63,6 @@ describe('attach remote', function () {
     });
 
     afterEach(async function () {
-        // Set max 30s timeout because disconnectRequest() in dc.stop() can hang
-        // if a failing test left GDB in an unexpected state, causing us to miss
-        // the backtrace output.
-        if (this.timeout() > 30000) {
-            this.timeout(30000);
-        }
         await gdbserver.kill();
         await dc.stop();
     });

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -151,4 +151,25 @@ describe('attach remote', function () {
         ]);
         expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
     });
+
+    it('can detach from a running program', async function () {
+        const attachArgs = fillDefaults(this.test, {
+            program: program,
+            target: {
+                type: 'remote',
+                parameters: [`localhost:${port}`],
+            } as TargetAttachArguments,
+        } as TargetAttachRequestArguments);
+
+        await Promise.all([
+            dc
+                .waitForEvent('initialized')
+                .then(() => dc.configurationDoneRequest()),
+            dc.initializeRequest().then(() => dc.attachRequest(attachArgs)),
+        ]);
+
+        // The program is started and running, nothing to do here anymore, what
+        // we are testing is whether afterEach() can still disconnect after
+        // having killed the gdbserver.
+    });
 });


### PR DESCRIPTION
This is a follow-up to #416, discovered while working on top of #407, although the problem has existed before. The problem is not severe, but it has gotten in my way while working on something else.

When the debugged program has exited after it was, to the adapter’s knowledge, running, a `disconnect` request gets stuck and never completes, because `GDBTargetDebugSession.doDisconnectRequest` tries to pause the program before issuing the `disconnect` command to GDB, but the stop notification that it expects as confirmation that the pause has taken effect never arrives, because there are no threads anymore that could stop.

This happens in the `attachRemote` tests, whose `afterEach` function first kills the gdbserver, which causes GDB to consider the program exited, and then in `DebugClient.stop()` sends a disconnect request. It causes the test to fail with a timeout in the "after each" hook.

The problem can also be reproduced manually in Visual Studio Code, to some extent: After launching with the following launch configuration and waiting 10 seconds for the program to exit, while there is no obvious corruption of the front-end (it seems to clean up the debug session properly after receiving the `terminated` event), you can see in the Debug Console that the `disconnect` request from the client never receives a response and a `disconnect` command is never sent to GDB.

```json
		{
			"debugServer": 4711,
			"type": "gdbtarget",
			"request": "attach",
			"name": "Local Program CDT GDB Debug",
			"program": "cdt-gdb-adapter/src/integration-tests/test-programs/loopforever",
			"gdbNonStop": true,
			"verbose": true,
			"target": {
				"parameters": ["| gdbserver - cdt-gdb-adapter/src/integration-tests/test-programs/loopforever"]
			}
		},
```

This was not noticed so far because all the tests in attachRemote.spec.ts happen to end with the program suspended, so no pausing was deemed necessary. I happened on it as I was adding a test that ends while the program is running.

The first commit adds a test for just this condition, which currently fails with a timeout in its "after each" hook, in all test scenarios except the `gdb-async-off` ones (where the `requireAsync` check suppresses the pausing).

The second commit fixes the problem and makes the test pass.

Note that to fix the problem also in all-stop mode, I had to take the `queryCurrentThreadId()` call out of the "if non-stop". I am not entirely happy about that – that call was never primarily meant to detect the problematic condition, it just did that as an accidental side effect. That only works in async mode, but since the problem occurs only there, that seems okay.

There is still a race condition in that the program (or just the chosen thread) could exit between the `queryCurrentThreadId()` and the `pause()`, but I’m not sure what a good way around that would be. GDB does not seem to send individual `thread-exited` notifications when the whole process goes away, only a `thread-group-exited`, and we don’t seem to keep track of thread groups. In the interest of not letting the perfect be the enemy of the good, I am inclined to leave this unfixed. But if others disagree I don’t mind doing more work on it.

The third commit is in response to https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/407#issuecomment-3211147821 and tentatively removes the test timeout reduction I inserted as a stop-gap as part of #407, because with some likelihood the symptom described in its comment that was getting in my way during development was caused by the issue fixed here. If the symptom reappears, it can always be investigated in more detail at that point.
