### PR TITLE
Fix my own flaky test

### DIFF
--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -140,11 +140,15 @@ describe('attach remote', function () {
         ]);
 
         // If that seems to have worked, check that we ended up in a sane state.
-        await dc.pauseRequest({ threadId: 1 });
-        await dc.waitForEvent('stopped');
+        await Promise.all([
+            dc.waitForEvent('stopped'),
+            dc.pauseRequest({ threadId: 1 }),
+        ]);
         await dc.evaluate('stop = 1');
-        await dc.continueRequest({ threadId: 1 });
-        await dc.assertStoppedLocation('breakpoint', { line: 28 });
+        await Promise.all([
+            dc.assertStoppedLocation('breakpoint', { line: 28 }),
+            dc.continueRequest({ threadId: 1 }),
+        ]);
         expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
     });
 });


### PR DESCRIPTION
Turns out I am guilty myself of the crime that I accused others of in #433: Tests that start waiting for an event only after the call that triggers the event and therefore occasionally miss it (introduced in #407).