### PR TITLE
Fix erroneous assumption of async mode when target does not support it

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -612,6 +612,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             }
+            if (this.gdb.getAsyncMode()) {
+                if (await this.gdb.confirmAsyncMode()) {
+                    this.warnAsyncDisabled();
+                }
+            }
 
             await this.setSessionState(SessionState.CONNECTED);
 

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -612,11 +612,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             }
-            if (this.gdb.getAsyncMode()) {
-                if (await this.gdb.confirmAsyncMode()) {
-                    this.warnAsyncDisabled();
-                }
-            }
 
             await this.setSessionState(SessionState.CONNECTED);
 
@@ -624,6 +619,14 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             await this.executeOrAbort(this.gdb.sendCommands.bind(this.gdb))(
                 args.initCommands
             );
+
+            // Check for async mode support after initCommands have possibly
+            // selected a different target
+            if (this.gdb.getAsyncMode()) {
+                if (await this.gdb.confirmAsyncMode()) {
+                    this.warnAsyncDisabled();
+                }
+            }
 
             // Initialize UART
             if (target.uart !== undefined) {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -393,11 +393,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             this.sendEvent(
                 new OutputEvent(`attached to process ${attachArgs.processId}`)
             );
-            if (this.gdb.getAsyncMode()) {
-                if (await this.gdb.confirmAsyncMode()) {
-                    this.warnAsyncDisabled();
-                }
-            }
         } else {
             if (this.gdb.getAsyncMode()) {
                 // Checking whether the target supports async mode needs a
@@ -409,13 +404,18 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     type: 'native',
                     parameters: [],
                 });
-                if (await this.gdb.confirmAsyncMode()) {
-                    this.warnAsyncDisabled();
-                }
             }
         }
 
         await this.gdb.sendCommands(args.initCommands);
+
+        // Check for async mode support after initCommands have possibly
+        // selected a different target
+        if (this.gdb.getAsyncMode()) {
+            if (await this.gdb.confirmAsyncMode()) {
+                this.warnAsyncDisabled();
+            }
+        }
 
         if (request === 'launch') {
             const launchArgs = args as LaunchRequestArguments;

--- a/src/mi/base.ts
+++ b/src/mi/base.ts
@@ -17,6 +17,11 @@ export interface MIShowResponse extends MIResponse {
     value?: string;
 }
 
+/** Response to -list-features and -list-target-features */
+export interface MIFeaturesResponse extends MIResponse {
+    features?: string[];
+}
+
 export abstract class MIRequest<R> {
     public abstract send(backend: IGDBBackend): Promise<R>;
 }

--- a/src/types/gdb.ts
+++ b/src/types/gdb.ts
@@ -86,6 +86,8 @@ export interface IGDBBackend extends EventEmitter {
 
     getAsyncMode: () => boolean;
 
+    confirmAsyncMode: () => Promise<boolean>;
+
     setNonStopMode: (isSet?: boolean) => Promise<void>;
 
     isNonStopMode: () => boolean;

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -461,11 +461,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             }
-            if (this.gdb.getAsyncMode()) {
-                if (await this.gdb.confirmAsyncMode()) {
-                    this.warnAsyncDisabled();
-                }
-            }
 
             await this.setSessionState(SessionState.CONNECTED);
 
@@ -473,6 +468,14 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             await this.executeOrAbort(this.gdb.sendCommands.bind(this.gdb))(
                 args.initCommands
             );
+
+            // Check for async mode support after initCommands have possibly
+            // selected a different target
+            if (this.gdb.getAsyncMode()) {
+                if (await this.gdb.confirmAsyncMode()) {
+                    this.warnAsyncDisabled();
+                }
+            }
 
             // Load additional code/symbols
             if (args.imageAndSymbols) {

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -461,6 +461,11 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     )
                 );
             }
+            if (this.gdb.getAsyncMode()) {
+                if (await this.gdb.confirmAsyncMode()) {
+                    this.warnAsyncDisabled();
+                }
+            }
 
             await this.setSessionState(SessionState.CONNECTED);
 


### PR DESCRIPTION
The `-gdb-set mi-async on` command currently used ([documentation](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Asynchronous-and-non_002dstop-modes.html)), even when it suceeds, does not guarantee that GDB will actually enter async mode, it only announces a preference. Entering async mode additionally requires support from the target. If the adapter is later going to make decisions based on whether GDB is in async mode, it needs to check whether that is actually the case, not just rely on its own preference.

In particular, the `native` target on Windows does not support async mode, so during local debugging on Windows with a launch configuration that does not set `gdbAsync: false`, `gdb.getAsyncMode()` currently erroneously returns true and any decisions based on that are wrong. In such cases, the adapter may issue commands, expecting that they will be serviced promptly, and get stuck because they are in reality only serviced next time the target stops.

In the current main branch, there is only one such decision, in `GDBDebugSessionBase.pauseIfNeeded`, but more are about to be added (by me) in #437 and #439. The first one may be harmless, as it only guards a `gdb.pause()` call that should also work in sync mode (I’m not sure whether it actually does on Windows, see https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/commit/a481615a446038bbd5c1419d028b96b996414018). The one from #437 might cause the adapter to get stuck when setting breakpoints while the program is running, but I have not tried it (there is a test for that, but it is skipped on Windows – possibly because the feature has never worked there, for the same reason). The one from #439 definitely causes problems, as seen in a failed CI run there.

So this must either be fixed, or #437 and #439 must be reworked because `GDBBackend.getAsyncMode()` does a different thing than I expect and I am misusing it in those. I hereby vote for the former.

According to the documentation,
> After the frontend has started the executable or attached to the target, it can find if asynchronous execution is enabled using the `-list-target-features` command.

Some experimentation and a look at the source code seem to suggest that the executable need not actually be started (which is good, because once it’s started, it’s running, and if we are unexpectedly in sync mode, we can’t even send the command to discover that at that time), but GDB does need to be connected to a target. Connection to a target happens either explicitly using the `target`/`-select-target` command (in the remote case) or implicitly to the `native` target using `run`/`-exec-run` or `attach`/`-target-attach` (see [`set auto-connect-native-target`](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Starting.html#set-auto_002dconnect_002dnative_002dtarget)) (in the local case). These commands happen in slightly different places in the adapter in remote/local/launch/attach scenarios, and they may even be part of `target.connectCommands` supplied by the user rather than explicitly issued by the adapter (the latter is the case for Indel).

I think I have covered all those places in the attached proposed fix. I would however in particular appreciate another set of eyes on where I explicitly do `-target-select native` because when it would be done implicitly by `-exec-run` later it would be too late in the unexpectedly-sync case. Are we actually guaranteed to end up with the `native` target at this point so this does not break anything, or am I missing any corner cases?