### PR TITLE
Adding Data Breakpoint support for complex data types

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -700,7 +700,20 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             if (numberRegex.test(bp.dataId) || bp.dataId.startsWith('0x')) {
                 bp.dataId = `*(${bp.dataId})`;
             }
-            await mi.sendBreakWatchpoint(this.gdb, bp.dataId, bp.accessType);
+            try {
+                await mi.sendBreakWatchpoint(
+                    this.gdb,
+                    bp.dataId,
+                    bp.accessType
+                );
+            } catch (err) {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    'Data breakpoint could not be created: ' +
+                        (err instanceof Error ? err.message : String(err))
+                );
+            }
         }
         // Get the updated list of GDB watchpoints
         const gdbWatchpoints = await this.getWatchpointList();

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -586,6 +586,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         } else {
             // Try to evaluate the address of the expression to see if it's a valid symbol
             try {
+                const isFunction = await mi.sendSymbolInfoFunctions(this.gdb, { name: `^${varExpression}$` });
+                if(isFunction.symbols.debug.length > 0) { 
+                    throw new Error(`Cannot set data breakpoint for function ${varExpression}`); 
+                }
                 const address = await mi.sendDataEvaluateExpression(this.gdb, `&${varExpression}` );
                 const size = await mi.sendDataEvaluateExpression(this.gdb, `sizeof(${varExpression})` );
                 if (address.value && size.value) {
@@ -596,11 +600,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         canPersist: true,
                     };
                 } else {
-                    response.body = {
-                        dataId: null,
-                        description: `No data breakpoint for ${varExpression}`,
-                    };
-                }
+                response.body = {
+                    dataId: null,
+                    description: `No data breakpoint for ${varExpression}`,
+                };
+            }
             } catch {
                 // Silently failing, no data breakpoint can be set for the expression
                 response.body = {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -587,7 +587,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             // Try to evaluate the address of the expression to see if it's a valid symbol
             try {
                 const isFunction = await mi.sendSymbolInfoFunctions(this.gdb, { name: `^${varExpression}$` });
-                if(isFunction.symbols.debug.length > 0) { 
+                if(isFunction.symbols.debug) { 
                     throw new Error(`Cannot set data breakpoint for function ${varExpression}`); 
                 }
                 const address = await mi.sendDataEvaluateExpression(this.gdb, `&${varExpression}` );

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -586,12 +586,22 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         } else {
             // Try to evaluate the address of the expression to see if it's a valid symbol
             try {
-                const isFunction = await mi.sendSymbolInfoFunctions(this.gdb, { name: `^${varExpression}$` });
-                if(isFunction.symbols.debug) { 
-                    throw new Error(`Cannot set data breakpoint for function ${varExpression}`); 
+                const isFunction = await mi.sendSymbolInfoFunctions(this.gdb, {
+                    name: `^${varExpression}$`,
+                });
+                if (isFunction.symbols.debug) {
+                    throw new Error(
+                        `Cannot set data breakpoint for function ${varExpression}`
+                    );
                 }
-                const address = await mi.sendDataEvaluateExpression(this.gdb, `&${varExpression}` );
-                const size = await mi.sendDataEvaluateExpression(this.gdb, `sizeof(${varExpression})` );
+                const address = await mi.sendDataEvaluateExpression(
+                    this.gdb,
+                    `&${varExpression}`
+                );
+                const size = await mi.sendDataEvaluateExpression(
+                    this.gdb,
+                    `sizeof(${varExpression})`
+                );
                 if (address.value && size.value) {
                     response.body = {
                         dataId: varExpression,
@@ -600,11 +610,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         canPersist: true,
                     };
                 } else {
-                response.body = {
-                    dataId: null,
-                    description: `No data breakpoint for ${varExpression}`,
-                };
-            }
+                    response.body = {
+                        dataId: null,
+                        description: `No data breakpoint for ${varExpression}`,
+                    };
+                }
             } catch {
                 // Silently failing, no data breakpoint can be set for the expression
                 response.body = {

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -251,6 +251,22 @@ describe('breakpoints', async function () {
         expect(bpResp.body.breakpoints.length).eq(1);
     });
 
+    it('fails to set a data breakpoint for a non symbol', async function () {
+        const isEligible = await dc.dataBreakpointInfoRequest({
+            name: 'r0',
+        });
+        expect(isEligible.body).not.eq(undefined);
+        expect(isEligible.body.dataId).eq(null);
+    });
+
+    it('fails to set a data breakpoint for a function', async function () {
+        const isEligible = await dc.dataBreakpointInfoRequest({
+            name: 'main',
+        });
+        expect(isEligible.body).not.eq(undefined);
+        expect(isEligible.body.dataId).eq(null);
+    });
+
     it('sets a data breakpoint for an address', async function () {
         await dc.setBreakpointsRequest({
             source: {

--- a/src/mi/index.ts
+++ b/src/mi/index.ts
@@ -16,3 +16,4 @@ export * from './target';
 export * from './thread';
 export * from './var';
 export * from './interpreter';
+export * from './symbols';

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -69,7 +69,7 @@ export function sendSymbolInfoFunctions(
         max_result?: string;
         non_debug?: boolean;
     }
-) : Promise<MISymbolInfoResponse> {
+): Promise<MISymbolInfoResponse> {
     let command = '-symbol-info-functions';
     if (params) {
         if (params.name) {

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -1,0 +1,89 @@
+/*********************************************************************
+ * Copyright (c) 2018 QNX Software Systems and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { IGDBBackend } from '../types/gdb';
+
+export interface MIDebugSymbol {
+    line: string;
+    name: string;
+    type: string;
+    description: string;
+}
+
+export interface MINonDebugSymbol {
+    address: string;
+    name: string;
+}
+
+export interface MISymbolInfoDebug {
+    filename: string;
+    fullname: string;
+    symbols: MIDebugSymbol[];
+}
+
+export interface MISymbolInfoResponse {
+    symbols: {
+        debug: MISymbolInfoDebug[];
+        nondebug: MINonDebugSymbol[];
+    };
+}
+
+export function sendSymbolInfoVars(
+    gdb: IGDBBackend,
+    params?: {
+        name?: string;
+        type?: string;
+        max_result?: string;
+        non_debug?: boolean;
+    }
+): Promise<MISymbolInfoResponse> {
+    let command = '-symbol-info-variables';
+    if (params) {
+        if (params.name) {
+            command += ` --name ${params.name}`;
+        }
+        if (params.type) {
+            command += ` --type ${params.type}`;
+        }
+        if (params.max_result) {
+            command += ` --max-result ${params.max_result}`;
+        }
+        if (params.non_debug) {
+            command += ' --include-nondebug';
+        }
+    }
+    return gdb.sendCommand(command);
+}
+
+export function sendSymbolInfoFunctions(
+    gdb: IGDBBackend,
+    params?: {
+        name?: string;
+        type?: string;
+        max_result?: string;
+        non_debug?: boolean;
+    }
+) : Promise<MISymbolInfoResponse> {
+    let command = '-symbol-info-functions';
+    if (params) {
+        if (params.name) {
+            command += ` --name ${params.name}`;
+        }
+        if (params.type) {
+            command += ` --type ${params.type}`;
+        }
+        if (params.max_result) {
+            command += ` --max-result ${params.max_result}`;
+        }
+        if (params.non_debug) {
+            command += ' --include-nondebug';
+        }
+    }
+    return gdb.sendCommand(command);
+}

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2018 QNX Software Systems and others
+ * Copyright (c) 2025 QNX Software Systems, Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -69,28 +69,6 @@ export interface MIVarPathInfoResponse {
     path_expr: string;
 }
 
-export interface MIDebugSymbol {
-    line: string;
-    name: string;
-    type: string;
-    description: string;
-}
-
-export interface MINonDebugSymbol {
-    address: string;
-    name: string;
-}
-export interface MISymbolInfoVarsDebug {
-    filename: string;
-    fullname: string;
-    symbols: MIDebugSymbol[];
-}
-export interface MISymbolInfoVarsResponse {
-    symbols: {
-        debug: MISymbolInfoVarsDebug[];
-        nondebug: MINonDebugSymbol[];
-    };
-}
 function quote(expression: string) {
     return `"${expression}"`;
 }
@@ -226,32 +204,5 @@ export function sendVarSetFormatToHex(
     name: string
 ): Promise<void> {
     const command = `-var-set-format ${name} hexadecimal`;
-    return gdb.sendCommand(command);
-}
-
-export function sendSymbolInfoVars(
-    gdb: IGDBBackend,
-    params?: {
-        name?: string;
-        type?: string;
-        max_result?: string;
-        non_debug?: boolean;
-    }
-): Promise<MISymbolInfoVarsResponse> {
-    let command = '-symbol-info-variables';
-    if (params) {
-        if (params.name) {
-            command += ` --name ${params.name}`;
-        }
-        if (params.type) {
-            command += ` --type ${params.type}`;
-        }
-        if (params.max_result) {
-            command += ` --max-result ${params.max_result}`;
-        }
-        if (params.non_debug) {
-            command += ' --include-nondebug';
-        }
-    }
     return gdb.sendCommand(command);
 }


### PR DESCRIPTION
Previously, we only supported Data Breakpoints for variables of simple data types. i.e. no support for array elements, structures, or class attributes.
In this PR, I changed the eligibility philosophy for data breakpoints. Basically, the functino `dataBreakpointInfo` would accept any expression that:
1. is an actual address
2. evaluates to an actual address
3. is not a global function name

This will obviously make data breakpoints more inclusive to users