### PR TITLE
Support auxiliary GDB with target parameters/connectCommands

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -678,18 +678,20 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             if (args.auxiliaryGdb && this.auxGdb) {
                 this.logGDBRemote('connect auxiliary GDB to target');
                 // Use connect commands to connect auxiliary GDB.
-                const connectCommands: string[] = [
-                    ...AuxiliaryConnectCommands
-                ];
+                const connectCommands: string[] = [...AuxiliaryConnectCommands];
                 if (target.connectCommands) {
                     connectCommands.push(...target.connectCommands);
                 } else {
-                    connectCommands.push(`target ${targetType} ${targetParameters.join(' ')}`);
+                    connectCommands.push(
+                        `target ${targetType} ${targetParameters.join(' ')}`
+                    );
                 }
                 await this.executeOrAbort(
                     this.auxGdb.sendCommands.bind(this.auxGdb)
                 )(connectCommands);
-                this.sendEvent(new OutputEvent('connect auxiliary GDB to target'));
+                this.sendEvent(
+                    new OutputEvent('connect auxiliary GDB to target')
+                );
             }
 
             await this.setSessionState(SessionState.CONNECTED);

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -642,13 +642,13 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             const targetString = targetHost
                 ? `${targetHost}:${targetPort}`
                 : undefined;
+            const defaultTarget = targetString ? [targetString] : [];
+            const targetParameters = target.parameters ?? defaultTarget;
+            const targetType = target.type ?? 'remote';
 
             // Connect to remote server
             if (target.connectCommands === undefined) {
-                this.targetType =
-                    target.type !== undefined ? target.type : 'remote';
-                const defaultTarget = targetString ? [targetString] : [];
-                const targetParameters = target.parameters ?? defaultTarget;
+                this.targetType = targetType;
                 await this.executeOrAbort(mi.sendTargetSelectRequest.bind(mi))(
                     this.gdb,
                     {
@@ -676,16 +676,20 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             }
 
             if (args.auxiliaryGdb && this.auxGdb) {
+                this.logGDBRemote('connect auxiliary GDB to target');
                 // Use connect commands to connect auxiliary GDB.
-                this.logGDBRemote('connect to auxiliary GDB');
                 const connectCommands: string[] = [
-                    ...AuxiliaryConnectCommands,
-                    `target remote ${targetString}`,
+                    ...AuxiliaryConnectCommands
                 ];
+                if (target.connectCommands) {
+                    connectCommands.push(...target.connectCommands);
+                } else {
+                    connectCommands.push(`target ${targetType} ${targetParameters.join(' ')}`);
+                }
                 await this.executeOrAbort(
                     this.auxGdb.sendCommands.bind(this.auxGdb)
                 )(connectCommands);
-                this.sendEvent(new OutputEvent('connected to auxiliary GDB'));
+                this.sendEvent(new OutputEvent('connect auxiliary GDB to target'));
             }
 
             await this.setSessionState(SessionState.CONNECTED);

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -690,8 +690,9 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     this.auxGdb.sendCommands.bind(this.auxGdb)
                 )(connectCommands);
                 this.sendEvent(
-                    new OutputEvent('connect auxiliary GDB to target')
+                    new OutputEvent('connected auxiliary GDB to target')
                 );
+                this.logGDBRemote('connected auxiliary GDB to target');
             }
 
             await this.setSessionState(SessionState.CONNECTED);

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -198,7 +198,9 @@ describe('auxiliary gdb', function () {
         );
         // Test if relevant output events came during 'beforeEach'
         expect(
-            stdOutputContains('GDB Remote session: connected auxiliary GDB to target')
+            stdOutputContains(
+                'GDB Remote session: connected auxiliary GDB to target'
+            )
         ).to.be.true;
         expect(
             stdOutputContains(

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -198,7 +198,7 @@ describe('auxiliary gdb', function () {
         );
         // Test if relevant output events came during 'beforeEach'
         expect(
-            stdOutputContains('GDB Remote session: connect to auxiliary GDB')
+            stdOutputContains('GDB Remote session: connected auxiliary GDB to target')
         ).to.be.true;
         expect(
             stdOutputContains(

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -48,6 +48,8 @@ describe('auxiliary gdb configuration', function () {
         }
     });
 
+    const auxUnsupported = gdbNonStop || gdbAsync === false || !isRemoteTest;
+
     const testConnect = async (
         launchArgs: TargetLaunchRequestArguments,
         expectToFail: boolean
@@ -71,6 +73,10 @@ describe('auxiliary gdb configuration', function () {
     };
 
     it('correctly validates if auxiliary gdb mode can work with other settings', async function () {
+        if (!isRemoteTest) {
+            this.skip();
+        }
+
         const expectToFail = gdbNonStop || gdbAsync === false;
 
         const launchArgs = fillDefaults(this.test, {
@@ -82,7 +88,9 @@ describe('auxiliary gdb configuration', function () {
     });
 
     it('can establish auxiliary gdb connection with target parameters', async function () {
-        const expectToFail = gdbNonStop || gdbAsync === false;
+        if (auxUnsupported) {
+            this.skip();
+        }
 
         const launchArgs = fillDefaults(this.test, {
             program,
@@ -94,11 +102,13 @@ describe('auxiliary gdb configuration', function () {
             },
         } as TargetLaunchRequestArguments);
 
-        await testConnect(launchArgs, expectToFail);
+        await testConnect(launchArgs, false);
     });
 
     it('can establish auxiliary gdb connection with target connect commands', async function () {
-        const expectToFail = gdbNonStop || gdbAsync === false;
+        if (auxUnsupported) {
+            this.skip();
+        }
 
         const launchArgs = fillDefaults(this.test, {
             program,
@@ -110,7 +120,7 @@ describe('auxiliary gdb configuration', function () {
             },
         } as TargetLaunchRequestArguments);
 
-        await testConnect(launchArgs, expectToFail);
+        await testConnect(launchArgs, false);
     });
 });
 

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -48,7 +48,10 @@ describe('auxiliary gdb configuration', function () {
         }
     });
 
-    const testConnect = async (launchArgs: TargetLaunchRequestArguments, expectToFail: boolean) => {
+    const testConnect = async (
+        launchArgs: TargetLaunchRequestArguments,
+        expectToFail: boolean
+    ) => {
         if (expectToFail) {
             // Expecting launch to fail, check for correct error message
             const expectedErrorMessage = gdbNonStop
@@ -85,15 +88,9 @@ describe('auxiliary gdb configuration', function () {
             program,
             auxiliaryGdb: true,
             target: {
-                parameters: [
-                    'localhost:3333'
-                ],
+                parameters: ['localhost:3333'],
                 serverPortRegExp: 'Listening on port',
-                serverParameters: [
-                    '--once',
-                    ':3333',
-                    program
-                ]
+                serverParameters: ['--once', ':3333', program],
             },
         } as TargetLaunchRequestArguments);
 
@@ -107,15 +104,9 @@ describe('auxiliary gdb configuration', function () {
             program,
             auxiliaryGdb: true,
             target: {
-                connectCommands: [
-                    '-target-select remote localhost:3333'
-                ],
+                connectCommands: ['-target-select remote localhost:3333'],
                 serverPortRegExp: 'Listening on port',
-                serverParameters: [
-                    '--once',
-                    ':3333',
-                    program
-                ]
+                serverParameters: ['--once', ':3333', program],
             },
         } as TargetLaunchRequestArguments);
 

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -48,14 +48,7 @@ describe('auxiliary gdb configuration', function () {
         }
     });
 
-    it('correctly validates if auxiliary gdb mode can work with other settings', async function () {
-        const expectToFail = gdbNonStop || gdbAsync === false;
-
-        const launchArgs = fillDefaults(this.test, {
-            program,
-            auxiliaryGdb: true,
-        } as TargetLaunchRequestArguments);
-
+    const testConnect = async (launchArgs: TargetLaunchRequestArguments, expectToFail: boolean) => {
         if (expectToFail) {
             // Expecting launch to fail, check for correct error message
             const expectedErrorMessage = gdbNonStop
@@ -72,6 +65,61 @@ describe('auxiliary gdb configuration', function () {
             )) as DebugProtocol.LaunchResponse;
             expect(launchResponse.success).to.be.true;
         }
+    };
+
+    it('correctly validates if auxiliary gdb mode can work with other settings', async function () {
+        const expectToFail = gdbNonStop || gdbAsync === false;
+
+        const launchArgs = fillDefaults(this.test, {
+            program,
+            auxiliaryGdb: true,
+        } as TargetLaunchRequestArguments);
+
+        await testConnect(launchArgs, expectToFail);
+    });
+
+    it('can establish auxiliary gdb connection with target parameters', async function () {
+        const expectToFail = gdbNonStop || gdbAsync === false;
+
+        const launchArgs = fillDefaults(this.test, {
+            program,
+            auxiliaryGdb: true,
+            target: {
+                parameters: [
+                    'localhost:3333'
+                ],
+                serverPortRegExp: 'Listening on port',
+                serverParameters: [
+                    '--once',
+                    ':3333',
+                    program
+                ]
+            },
+        } as TargetLaunchRequestArguments);
+
+        await testConnect(launchArgs, expectToFail);
+    });
+
+    it('can establish auxiliary gdb connection with target connect commands', async function () {
+        const expectToFail = gdbNonStop || gdbAsync === false;
+
+        const launchArgs = fillDefaults(this.test, {
+            program,
+            auxiliaryGdb: true,
+            target: {
+                connectCommands: [
+                    '-target-select remote localhost:3333'
+                ],
+                serverPortRegExp: 'Listening on port',
+                serverParameters: [
+                    '--once',
+                    ':3333',
+                    program
+                ]
+            },
+        } as TargetLaunchRequestArguments);
+
+        await testConnect(launchArgs, expectToFail);
     });
 });
 


### PR DESCRIPTION
Follow up to feedback for #449 :

Enables support for auxiliary GDB connections when using target parameters or target connect commands.
See https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/449#pullrequestreview-3289635301