### PR TITLE
Consistently use threadId in MI sendStackInfoDepth.

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1622,6 +1622,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 args.name.replace(/^\[(\d+)\]/, '$1');
             const stackDepth = await mi.sendStackInfoDepth(this.gdb, {
                 maxDepth: 100,
+                threadId: frameRef.threadId,
             });
             const depth = parseInt(stackDepth.depth, 10);
             let varobj = this.gdb.varManager.getVar(
@@ -2590,6 +2591,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         // stack depth necessary for differentiating between similarly named variables at different stack depths
         const stackDepth = await mi.sendStackInfoDepth(this.gdb, {
             maxDepth: 100,
+            threadId: frameRef.threadId,
         });
         const depth = parseInt(stackDepth.depth, 10);
 


### PR DESCRIPTION
Related to #451 

Use the parameter consistently, it is available in all places.

Staring at the new test from #452 for a while and methods how to test the depth-stuff in general. But I am starting to have doubts that testing through variable access on integration level is the right level to do that.

What we really need to understand is whether the thread ID is propagated correctly, which means tracking logs to see parameters are passed as expected. And I am a little hesitant to spend a lot of effort on testing the caching right now which clearly needs a bit of rework.

Alternative would be to restore the previous behavior of passing threadId to stack-depth calls exactly as before to avoid regressions.