### PR TITLE
Workaround for #446 after `windows-2022` runner image updates

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: git diff --exit-code
   Build-on-Windows:
     name: Build & Test on Windows
-    runs-on: Windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -51,7 +51,7 @@ jobs:
         run: git diff --exit-code
   Build-on-Windows:
     name: Build & Test on Windows
-    runs-on: Windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
This PR gets CI going again after a GitHub `windows-2022` runner image update that upgrade GNU tools, including an update from GDB 11.2 to 16.2. This resurfaced issues from #446 which had been suppressed for the time being by pinning runner to `windows-2022`.

It introduces the following changes:
* Move runner spec back to `windows-latest`. Pinning no longer helps with the workaround.
* Pin mingw installation step to fixed version which contains an older GDB. Unfortunately, that version (10.2) is even older than what was running on `windows-2022` before (11.2).
* Update Windows build jobs to add the chocolatey install to `GITHUB_PATH`. Which ensures it's present on `PATH` for following steps of that job.

Downgrading to GDB 10.2 for Windows testing isn't great. But quickest way to get CI going again.
Picking up #446 next as it's root causes become more and more a problem for our CI on Windows.