### PR TITLE
Not do set breakpoint request if there is no breakpoint when configuration phase has not completed yet

### DIFF
--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -795,4 +795,38 @@ describe('breakpoints', async function () {
         });
         expect(response.body.breakpoints.length).to.eq(1);
     });
+
+    it('empty breakpoint request if no breakpoint exists', async () => {
+        const response = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [],
+        });
+        expect(response.body.breakpoints.length).eq(0);
+    });
+
+    it('empty breakpoint request if a breakpoint exists', async () => {
+        await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                },
+            ],
+        });
+        const response = await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [],
+        });
+        expect(response.body.breakpoints.length).eq(0);
+    });
 });

--- a/src/integration-tests/functionBreakpoints.spec.ts
+++ b/src/integration-tests/functionBreakpoints.spec.ts
@@ -291,4 +291,25 @@ describe('function breakpoints', async function () {
         await dc.configurationDoneRequest();
         await dc.assertStoppedLocation('function breakpoint', { line: 10 });
     });
+
+    it('empty function breakpoint request if no breakpoint exists', async () => {
+        const bpResp = await dc.setFunctionBreakpointsRequest({
+            breakpoints: [],
+        });
+        expect(bpResp.body.breakpoints.length).eq(0);
+    });
+
+    it('empty function breakpoint request if a breakpoint exists', async () => {
+        await dc.setFunctionBreakpointsRequest({
+            breakpoints: [
+                {
+                    name: 'main',
+                },
+            ],
+        });
+        const bpResp = await dc.setFunctionBreakpointsRequest({
+            breakpoints: [],
+        });
+        expect(bpResp.body.breakpoints.length).eq(0);
+    });
 });


### PR DESCRIPTION
In configuration phase, breakpoint requests are still sent even there is no breakpoint was set. When do "set breakpoint request", continue and interrupt command could be sent to gdb and those commands could change the state of target unexpectedly. So should not do set breakpoint request if there is no breakpoint when configuration phase has not completed yet.