### PR TITLE
feat(updateThreadInfo): add option to disable update thread info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixes [`#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Fix initCommands behavior.
 - Fixes [`#483`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/483): `detach` request still occasionally getting stuck on exited program.
+- Implements [`#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add option to control when thread info is retrieved.
 
 ## 1.6.0
 

--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -220,6 +220,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     protected validateRequestArguments(
         args: TargetLaunchRequestArguments | TargetAttachRequestArguments
     ) {
+        super.validateRequestArguments(args);
         if (args.auxiliaryGdb) {
             // Limitations for auxiliary GDB mode
             if (args.gdbNonStop) {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -29,6 +29,7 @@ export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     hardwareBreakpoint?: boolean;
     customResetCommands?: string[];
     steppingResponseTimeout?: number;
+    updateThreadInfo?: 'missing' | 'when-requested' | 'never';
 }
 
 export interface LaunchRequestArguments extends RequestArguments {

--- a/src/web/GDBTargetDebugSession.ts
+++ b/src/web/GDBTargetDebugSession.ts
@@ -179,6 +179,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     protected validateRequestArguments(
         args: TargetLaunchRequestArguments | TargetAttachRequestArguments
     ) {
+        super.validateRequestArguments(args);
         if (args.auxiliaryGdb) {
             // Limitations for auxiliary GDB mode
             if (args.gdbNonStop) {


### PR DESCRIPTION
In very slow systems using eg. serial-console for remote debugging refreshing the threads makes the debugging unusable. On the other hand when the gdb hits a bp, the system is more-less responsible then getting the threads is disabled.

Closes #436 