### PR TITLE
Fix detach getting stuck on exited program, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixes [`#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Fix initCommands behavior.
+- Fixes [`#483`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/483): `detach` request still occasionally getting stuck on exited program.
 
 ## 1.6.0
 


### PR DESCRIPTION
This should fix the occasional test failures that I have various times commented with “the race condition from #437”, where `attachRemote` tests would time out in the “after each” hook.

In #437, I fixed the problem that the adapter would try to pause the target before detaching, but the `gdbserver` had been killed in the meantime, so there were no threads anymore that could stop, and the pause operation got stuck waiting for a stop notification. I did that by checking whether there still were any threads _before_ sending the pause request. As noted there, that leaves the race condition that the threads could disappear between the check and the request, in which case we would still get stuck. I dismissed that as “good enough” at the time, but since it has now been haunting us in the form of flaky tests, here is an attempt to do better.

With the attached change, the check is done _after_ the request, eliminating the race condition. It is done repeatedly on a timer during the interval between sending the request and either receiving a stop notification or discovering the bad condition, the first time after 1 second and then repeatedly every 2 seconds.

Polling rather than notification is used because in the specific case of the killed gdbserver I do not see any `thread-exited` notifications, and while I do see a `thread-group-exited` notification, I do not know whether that reliably occurs in other situations. Polling therefore seems both safer and easier than adding tracking of thread groups, which has not been done so far.

The numbers 1 second / 2 seconds are somewhat arbitrary, chosen long enough to minimize useless traffic, but short enough that the one second delay while detaching in the bad case (which should be rare in real usage, the test that kills gdbserver seems a somewhat contrived situation) is still acceptable. The 2 second repeat is probably rarely needed, I see no reason why a target that does eventually stop (the normal case) should take more than 3 seconds to do so.

This has the added advantage that in the normal case of a `pauseIfNeeded()` call where the target does have threads that can stop, the `queryCurrentThreadId()` call is never even done unless needed for other reasons (non-stop mode), saving us a round-trip to GDB, because the stop notification usually comes before the timer fires for the first time. That sets a lower bound for the useful initial timeout.

The test from #437 is left unmodified and still checks that the original problem is solved. I have also run some tests with artificial delays inserted in various places to exercise different timing constellations and found no problems.