### PR TITLE
Support target extended-remote launch connecting to gdbserver started…

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -265,11 +265,15 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         await this.setupCommonLoggerAndBackends(args);
         this.initializeSessionArguments(args);
 
+        this.isAttach = true;
         if (request === 'launch') {
-            const launchArgs = args as TargetLaunchRequestArguments;
-            await this.startGDBServer(launchArgs);
+            if (args.target?.type !== 'extended-remote') {
+                const launchArgs = args as TargetLaunchRequestArguments;
+                await this.startGDBServer(launchArgs);
+            } else
+                this.isAttach = false;
         }
-        await this.startGDBAndAttachToTarget(response, args);
+        await this.startGDBAndConnectToGDBSERVER(response, args);
     }
 
     protected async launchRequest(
@@ -632,7 +636,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         }
     }
 
-    protected async startGDBAndAttachToTarget(
+    protected async startGDBAndConnectToGDBSERVER(
         response: DebugProtocol.AttachResponse | DebugProtocol.LaunchResponse,
         args: TargetAttachRequestArguments
     ): Promise<void> {
@@ -641,7 +645,6 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         }
         const target = args.target;
         try {
-            this.isAttach = true;
             // Start GDB process
             this.logGDBRemote(`spawn GDB\n`);
             await this.spawn(args);


### PR DESCRIPTION
… with the --multi option

Patch is a 'works for me' solution to
1) Manually start 'gdbserver --multi :2345' on the remote target. 2) Debug the program from vscode by the following launch entry:

```
{
    "name": "Launch on remote target, which has gdbserver --multi :2345 running",
    "type": "gdbtarget",
    "request": "launch",
    "program": "${workspaceFolder}/out/build/x64_clang++/program",
    "gdbNonStop": true,
    "openGdbConsole": true,
    "target": {
	"type": "extended-remote",
	"parameters": [
		"192.168.22.1:2345"
	]
    }
    "initCommands": [
	"set remote exec-file /target/path/to/program"
    ]
}
```