### PR TITLE
Support value formatting

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2462,7 +2462,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.sendErrorResponse(
                     response,
                     1,
-                    'Unknown expression format specifier, supported specifiers are: x, d, o, b, z'
+                    'Unknown expression format specifier, supported specifiers are: x, d, o, b, t, z'
                 );
                 return;
             }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2093,7 +2093,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     false,
                     false,
                     varCreateResponse,
-                    'hexadecimal',
                     ref.type
                 );
                 await mi.sendVarSetFormat(
@@ -2468,14 +2467,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     frameRef,
                     frame: frameRef ? 'current' : 'floating',
                 });
-                // if format is undefined, skip the format command and return the value as-is, otherwise apply the requested formatting)
-                if (expressionDisplayFormat !== 'natural') {
-                    varCreateResponse.value = await mi.sendVarSetFormat(
-                        gdb,
-                        varCreateResponse.name,
-                        expressionDisplayFormat
-                    );
-                }
                 varobj = gdb.varManager.addVar(
                     frameRef,
                     depth,
@@ -2483,18 +2474,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     false,
                     false,
                     varCreateResponse,
-                    expressionDisplayFormat
                 );
             } else {
-                const currentFormat = varobj.displayFormat;
-                if (currentFormat !== expressionDisplayFormat) {
-                    varobj.value = await mi.sendVarSetFormat(
-                        gdb,
-                        varobj.varname,
-                        expressionDisplayFormat
-                    );
-                    varobj.displayFormat = expressionDisplayFormat;
-                }
                 const vup = await mi.sendVarUpdate(gdb, {
                     name: varobj.varname,
                 });
@@ -2517,31 +2498,32 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             expression,
                             frameRef,
                         });
-                        if (expressionDisplayFormat !== 'natural') {
-                            await mi.sendVarSetFormat(
-                                gdb,
-                                varCreateResponse.name,
-                                expressionDisplayFormat
-                            );
-                        }
                         varobj = gdb.varManager.addVar(
                             frameRef,
                             depth,
                             expression,
                             false,
                             false,
-                            varCreateResponse,
-                            expressionDisplayFormat
+                            varCreateResponse
                         );
                     }
                 }
             }
             if (varobj) {
                 const frameHandle = args.frameId ?? -1;
+                const hasChildren = args.context === 'variables' && Number(varobj.numchild);
                 const result =
-                    args.context === 'variables' && Number(varobj.numchild)
+                    hasChildren
                         ? await this.getChildElements(varobj, frameHandle)
-                        : varobj.value;
+                        : expressionDisplayFormat !== 'natural' ? await mi.sendVarSetFormat(
+                              gdb,
+                              varobj.varname,
+                              expressionDisplayFormat
+                          ) : varobj.value;
+                if (expressionDisplayFormat !== 'natural') {
+                    // restore original format after evaluation
+                    await mi.sendVarSetFormat(gdb, varobj.varname, 'natural');
+                }
                 const variablesReference =
                     parseInt(varobj.numchild, 10) > 0
                         ? this.variableHandles.create({

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -14,6 +14,7 @@ import {
     BreakpointEvent,
     Handles,
     InitializedEvent,
+    InvalidatedEvent,
     Logger,
     logger,
     LoggingDebugSession,
@@ -84,6 +85,12 @@ const threadAllRegex = /.*\s+\-\-all(\s+.*|$)/;
 interface StreamOutput {
     output: string;
     category: string;
+}
+
+// Interface for notify data of cmd-param-changed
+interface CmdParamChangedNotifyData {
+    param: string;
+    value: string;
 }
 
 // Interface for a pending pause request, used with pauseIfRunning() logic
@@ -2473,7 +2480,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     expression,
                     false,
                     false,
-                    varCreateResponse,
+                    varCreateResponse
                 );
             } else {
                 const vup = await mi.sendVarUpdate(gdb, {
@@ -2511,15 +2518,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             }
             if (varobj) {
                 const frameHandle = args.frameId ?? -1;
-                const hasChildren = args.context === 'variables' && Number(varobj.numchild);
-                const result =
-                    hasChildren
-                        ? await this.getChildElements(varobj, frameHandle)
-                        : expressionDisplayFormat !== 'natural' ? await mi.sendVarSetFormat(
-                              gdb,
-                              varobj.varname,
-                              expressionDisplayFormat
-                          ) : varobj.value;
+                const hasChildren =
+                    args.context === 'variables' && Number(varobj.numchild);
+                const result = hasChildren
+                    ? await this.getChildElements(varobj, frameHandle)
+                    : expressionDisplayFormat !== 'natural'
+                      ? await mi.sendVarSetFormat(
+                            gdb,
+                            varobj.varname,
+                            expressionDisplayFormat
+                        )
+                      : varobj.value;
                 if (expressionDisplayFormat !== 'natural') {
                     // restore original format after evaluation
                     await mi.sendVarSetFormat(gdb, varobj.varname, 'natural');
@@ -3065,6 +3074,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
     }
 
+    private handleCmdParamChanged(notifyData: CmdParamChangedNotifyData) {
+        switch (notifyData.param) {
+            case 'output-radix':
+                this.sendEvent(new InvalidatedEvent(['variables']));
+                break;
+            default:
+                break;
+        }
+    }
+
     protected handleGDBNotify(notifyClass: string, notifyData: any) {
         switch (notifyClass) {
             case 'thread-created':
@@ -3151,7 +3170,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 break;
             case 'cmd-param-changed':
-                // Known unhandled notifies
+                this.handleCmdParamChanged(notifyData);
                 break;
             default:
                 logger.warn(
@@ -3362,8 +3381,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         variable.name,
                         true,
                         false,
-                        varCreateResponse,
-                        'natural'
+                        varCreateResponse
                     );
                 } else {
                     // var existed as an expression before. Now it's a variable too.

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2327,10 +2327,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             case 'o':
                 returnedPair[1] = 'octal';
                 break;
-            case 't':
-                returnedPair[1] = 'binary';
-                break;
-            case 'b':
+            case 't': // GDB convention because 'b' already means 'byte'
+            case 'b': // VSCode convention
                 returnedPair[1] = 'binary';
                 break;
             case 'z':

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2093,9 +2093,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     false,
                     false,
                     varCreateResponse,
+                    'hexadecimal',
                     ref.type
                 );
-                await mi.sendVarSetFormatToHex(this.gdb, varobj.varname);
+                await mi.sendVarSetFormat(
+                    this.gdb,
+                    varobj.varname,
+                    'hexadecimal'
+                );
             }
             let assign;
             if (varobj) {
@@ -2298,6 +2303,46 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         return this.doEvaluateRequest(response, args, false);
     }
 
+    private extractExpressionFormat(
+        expression: string
+    ): [string, mi.DisplayFormat] {
+        // Extract last two characters from expression
+        const lastTwoChars = expression.slice(-2);
+        if (lastTwoChars[0] !== ',') {
+            return [expression, 'natural'];
+        }
+        const formatSpecifier = lastTwoChars[1];
+        const slicedExpression = expression.slice(0, -2).trim();
+        const returnedPair: [string, mi.DisplayFormat] = [
+            slicedExpression,
+            'natural',
+        ];
+        switch (formatSpecifier) {
+            case 'x':
+                returnedPair[1] = 'hexadecimal';
+                break;
+            case 'd':
+                returnedPair[1] = 'decimal';
+                break;
+            case 'o':
+                returnedPair[1] = 'octal';
+                break;
+            case 't':
+                returnedPair[1] = 'binary';
+                break;
+            case 'b':
+                returnedPair[1] = 'binary';
+                break;
+            case 'z':
+                returnedPair[1] = 'zero-hexadecimal';
+                break;
+            default:
+                returnedPair[1] = 'unknown';
+                break;
+        }
+        return returnedPair;
+    }
+
     protected async doEvaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments,
@@ -2320,7 +2365,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         try {
-            const expression = args.expression.trim();
+            let expression = args.expression.trim();
             const isCliCommand =
                 expression.startsWith('>') && args.context === 'repl';
             const isAux = this.auxGdb && this.isRunning;
@@ -2407,7 +2452,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             const [gdb, frameRef, depth] =
                 await this.getFrameContext(initialFrameRef);
-
+            const [actualExpression, expressionDisplayFormat] =
+                this.extractExpressionFormat(expression);
+            if (expressionDisplayFormat === 'unknown') {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    'Unknown expression format specifier, supported specifiers are: x, d, o, b, z'
+                );
+                return;
+            }
+            expression = actualExpression;
             let varobj = gdb.varManager.getVar(frameRef, depth, expression);
             if (!varobj) {
                 const varCreateResponse = await mi.sendVarCreate(gdb, {
@@ -2415,15 +2470,33 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     frameRef,
                     frame: frameRef ? 'current' : 'floating',
                 });
+                // if format is undefined, skip the format command and return the value as-is, otherwise apply the requested formatting)
+                if (expressionDisplayFormat !== 'natural') {
+                    varCreateResponse.value = await mi.sendVarSetFormat(
+                        gdb,
+                        varCreateResponse.name,
+                        expressionDisplayFormat
+                    );
+                }
                 varobj = gdb.varManager.addVar(
                     frameRef,
                     depth,
                     expression,
                     false,
                     false,
-                    varCreateResponse
+                    varCreateResponse,
+                    expressionDisplayFormat
                 );
             } else {
+                const currentFormat = varobj.displayFormat;
+                if (currentFormat !== expressionDisplayFormat) {
+                    varobj.value = await mi.sendVarSetFormat(
+                        gdb,
+                        varobj.varname,
+                        expressionDisplayFormat
+                    );
+                    varobj.displayFormat = expressionDisplayFormat;
+                }
                 const vup = await mi.sendVarUpdate(gdb, {
                     name: varobj.varname,
                 });
@@ -2446,13 +2519,21 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             expression,
                             frameRef,
                         });
+                        if (expressionDisplayFormat !== 'natural') {
+                            await mi.sendVarSetFormat(
+                                gdb,
+                                varCreateResponse.name,
+                                expressionDisplayFormat
+                            );
+                        }
                         varobj = gdb.varManager.addVar(
                             frameRef,
                             depth,
                             expression,
                             false,
                             false,
-                            varCreateResponse
+                            varCreateResponse,
+                            expressionDisplayFormat
                         );
                     }
                 }
@@ -3301,7 +3382,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         variable.name,
                         true,
                         false,
-                        varCreateResponse
+                        varCreateResponse,
+                        'natural'
                     );
                 } else {
                     // var existed as an expression before. Now it's a variable too.

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2523,16 +2523,13 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 const result = hasChildren
                     ? await this.getChildElements(varobj, frameHandle)
                     : expressionDisplayFormat !== 'natural'
-                      ? await mi.sendVarSetFormat(
-                            gdb,
-                            varobj.varname,
-                            expressionDisplayFormat
-                        )
+                      ? (
+                            await mi.sendVarEvaluateExpression(gdb, {
+                                varname: varobj.varname,
+                                format: expressionDisplayFormat,
+                            })
+                        ).value
                       : varobj.value;
-                if (expressionDisplayFormat !== 'natural') {
-                    // restore original format after evaluation
-                    await mi.sendVarSetFormat(gdb, varobj.varname, 'natural');
-                }
                 const variablesReference =
                     parseInt(varobj.numchild, 10) > 0
                         ? this.variableHandles.create({

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -13,7 +13,6 @@ import { CdtDebugClient } from './debugClient';
 import {
     expectRejection,
     fillDefaults,
-    //gdbAsync,
     getScopes,
     isRemoteTest,
     resolveLineTagLocations,
@@ -301,9 +300,6 @@ describe('evaluate request', function () {
     });
     
     it('should send invalidate event when changing global radix through evaluate request', async function () {
-        //if (!(isRemoteTest && gdbAsync)) {
-        //    this.skip();
-        //}
         const event = dc.waitForEvent('invalidated');
         await dc.evaluateRequest({
             context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -13,7 +13,7 @@ import { CdtDebugClient } from './debugClient';
 import {
     expectRejection,
     fillDefaults,
-    gdbAsync,
+    //gdbAsync,
     getScopes,
     isRemoteTest,
     resolveLineTagLocations,
@@ -301,9 +301,9 @@ describe('evaluate request', function () {
     });
     
     it('should send invalidate event when changing global radix through evaluate request', async function () {
-        if (!(isRemoteTest && gdbAsync)) {
-            this.skip();
-        }
+        //if (!(isRemoteTest && gdbAsync)) {
+        //    this.skip();
+        //}
         const event = dc.waitForEvent('invalidated');
         await dc.evaluateRequest({
             context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -13,6 +13,7 @@ import { CdtDebugClient } from './debugClient';
 import {
     expectRejection,
     fillDefaults,
+    gdbAsync,
     getScopes,
     isRemoteTest,
     resolveLineTagLocations,
@@ -165,6 +166,7 @@ describe('evaluate request', function () {
         });
         expect(res2.body.result).eq('10');
     });
+
     it('should be able to use GDB command', async function () {
         const res1 = await dc.evaluateRequest({
             context: 'repl',
@@ -181,6 +183,7 @@ describe('evaluate request', function () {
 
         expect(res2.body.result).eq('\r');
     });
+
     it('should reject entering an invalid MI command', async function () {
         const err = await expectRejection(
             dc.evaluateRequest({
@@ -271,6 +274,44 @@ describe('evaluate request', function () {
         );
 
         expect(err.message).to.startWith('Unknown expression format specifier');
+    });
+
+    it('should not change the format of a variable in the variables view while evaluating the same variable with a format specifier in the watch view', async function () {
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: 'monitor = 10',
+            frameId: scope.frame.id,
+        });
+
+        const watchResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,x',
+            frameId: scope.frame.id,
+        });
+        expect(watchResponse.body.result).to.equal('0xa');
+
+        const variableRequestResponse = await dc.variablesRequest({
+            variablesReference: scope.scopes.body.scopes[0].variablesReference,
+        });
+        const monitorVariable = variableRequestResponse.body.variables.find(
+            (variable) => variable.name === 'monitor'
+        );
+        expect(monitorVariable).to.not.be.undefined;
+        expect(monitorVariable?.value).to.equal('10');
+    });
+    
+    it('should send invalidate event when changing global radix through evaluate request', async function () {
+        if (!(isRemoteTest && gdbAsync)) {
+            this.skip();
+        }
+        const event = dc.waitForEvent('invalidated');
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: '> set output-radix 16',
+            frameId: scope.frame.id,
+        });
+        const invalidatedEvent = await event;
+        expect(invalidatedEvent).to.be.not.undefined;
     });
 });
 

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -192,6 +192,79 @@ describe('evaluate request', function () {
 
         expect(err.message).eq('Undefined MI command: a');
     });
+
+    it('should evaluate an expression with format specifier', async function () {
+        const res = await dc.evaluateRequest({
+            context: 'repl',
+            expression: '2 + 2,x',
+            frameId: scope.frame.id,
+        });
+        expect(res.body.result).eq('0x4');
+    });
+
+    it('should evaluate an expression with a non-default format specifier', async function () {
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: 'monitor = 10',
+            frameId: scope.frame.id,
+        });
+
+        const defaultResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor',
+            frameId: scope.frame.id,
+        });
+
+        const hexResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,x',
+            frameId: scope.frame.id,
+        });
+
+        const binaryResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,b',
+            frameId: scope.frame.id,
+        });
+
+        const octalResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,o',
+            frameId: scope.frame.id,
+        });
+
+        const decimalResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,d',
+            frameId: scope.frame.id,
+        });
+
+        expect(binaryResponse.body.result).to.equal('1010');
+        expect(defaultResponse.body.result).to.equal('10');
+        expect(hexResponse.body.result).to.equal('0xa');
+        expect(octalResponse.body.result).to.equal('012');
+        expect(decimalResponse.body.result).to.equal('10');
+
+        // Evaluate again without format specifier to check that the default format is not changed
+        const defaultResponse2 = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor',
+            frameId: scope.frame.id,
+        });
+        expect(defaultResponse2.body.result).to.equal('10');
+    });
+
+    it('should return an error if an invalid format specifier is used', async function () {
+        const err = await expectRejection(
+            dc.evaluateRequest({
+                context: 'repl',
+                expression: 'monitor,q',
+                frameId: scope.frame.id,
+            })
+        );
+
+        expect(err.message).to.startWith('Unknown expression format specifier');
+    });
 });
 
 describe('evaluate request global variables', function () {

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -13,7 +13,6 @@ import { CdtDebugClient } from './debugClient';
 import {
     expectRejection,
     fillDefaults,
-    gdbAsync,
     getScopes,
     isRemoteTest,
     resolveLineTagLocations,

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -227,6 +227,12 @@ describe('evaluate request', function () {
             frameId: scope.frame.id,
         });
 
+        const anotherBinaryResponse = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'monitor,t',
+            frameId: scope.frame.id,
+        });
+
         const octalResponse = await dc.evaluateRequest({
             context: 'watch',
             expression: 'monitor,o',
@@ -240,6 +246,7 @@ describe('evaluate request', function () {
         });
 
         expect(binaryResponse.body.result).to.equal('1010');
+        expect(anotherBinaryResponse.body.result).to.equal('1010');
         expect(defaultResponse.body.result).to.equal('10');
         expect(hexResponse.body.result).to.equal('0xa');
         expect(octalResponse.body.result).to.equal('012');

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -298,7 +298,7 @@ describe('evaluate request', function () {
         expect(monitorVariable).to.not.be.undefined;
         expect(monitorVariable?.value).to.equal('10');
     });
-    
+
     it('should send invalidate event when changing global radix through evaluate request', async function () {
         const event = dc.waitForEvent('invalidated');
         await dc.evaluateRequest({

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -206,14 +206,20 @@ export function sendVarAssign(
     return gdb.sendCommand(command);
 }
 
-export function sendVarEvaluateExpression(
+export async function sendVarEvaluateExpression(
     gdb: IGDBBackend,
     params: {
         varname: string;
+        format?: DisplayFormat;
     }
 ): Promise<MIVarEvalResponse> {
-    const command = `-var-evaluate-expression ${params.varname}`;
-    return gdb.sendCommand(command);
+    let command = `-var-evaluate-expression`;
+    if (params.format) {
+        command += ` -f ${params.format}`;
+    }
+    command += ` ${params.varname}`;
+    const result: MIVarEvalResponse = await gdb.sendCommand(command);
+    return result;
 }
 
 export function sendVarInfoPathExpression(

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -206,7 +206,7 @@ export function sendVarAssign(
     return gdb.sendCommand(command);
 }
 
-export async function sendVarEvaluateExpression(
+export function sendVarEvaluateExpression(
     gdb: IGDBBackend,
     params: {
         varname: string;
@@ -218,8 +218,7 @@ export async function sendVarEvaluateExpression(
         command += ` -f ${params.format}`;
     }
     command += ` ${params.varname}`;
-    const result: MIVarEvalResponse = await gdb.sendCommand(command);
-    return result;
+    return gdb.sendCommand(command);
 }
 
 export function sendVarInfoPathExpression(

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -11,6 +11,15 @@ import { IGDBBackend } from '../types/gdb';
 import { FrameReference } from '../types/session';
 import { MIResponse } from './base';
 
+export type DisplayFormat =
+    | 'hexadecimal'
+    | 'decimal'
+    | 'octal'
+    | 'binary'
+    | 'natural'
+    | 'zero-hexadecimal'
+    | 'unknown';
+
 export enum MIVarPrintValues {
     no = '0',
     all = '1',
@@ -67,6 +76,14 @@ export interface MIVarAssignResponse {
 
 export interface MIVarPathInfoResponse {
     path_expr: string;
+}
+
+export interface MIVarSetFormatResponse {
+    value: string;
+}
+
+export interface MIVarShowFormatResponse {
+    format: DisplayFormat;
 }
 
 function quote(expression: string) {
@@ -206,11 +223,30 @@ export function sendVarInfoPathExpression(
     const command = `-var-info-path-expression ${name}`;
     return gdb.sendCommand(command);
 }
-
+/** @deprecated This function is still here because it was added a long time ago and it might be used by other derived implementations. Please from now on use sendVarSetFormat instead of this function. */
 export function sendVarSetFormatToHex(
     gdb: IGDBBackend,
     name: string
 ): Promise<void> {
     const command = `-var-set-format ${name} hexadecimal`;
     return gdb.sendCommand(command);
+}
+
+export async function sendVarSetFormat(
+    gdb: IGDBBackend,
+    name: string,
+    format: DisplayFormat
+): Promise<string> {
+    const command = `-var-set-format ${name} ${format}`;
+    const response: MIVarSetFormatResponse = await gdb.sendCommand(command);
+    return response.value;
+}
+
+export async function sendVarShowFormat(
+    gdb: IGDBBackend,
+    name: string
+): Promise<DisplayFormat> {
+    const command = `-var-show-format ${name}`;
+    const response: MIVarShowFormatResponse = await gdb.sendCommand(command);
+    return response.format;
 }

--- a/src/varManager.ts
+++ b/src/varManager.ts
@@ -2,7 +2,6 @@ import { IGDBBackend } from './types/gdb';
 import { FrameReference } from './types/session';
 import {
     MIVarCreateResponse,
-    DisplayFormat,
     sendVarCreate,
     sendVarDelete,
     sendVarUpdate,
@@ -18,7 +17,6 @@ export interface VarObjType {
     isVar: boolean;
     isChild: boolean;
     varType: string;
-    displayFormat: DisplayFormat;
 }
 
 export class VarManager {
@@ -90,7 +88,6 @@ export class VarManager {
         isVar: boolean,
         isChild: boolean,
         varCreateResponse: MIVarCreateResponse,
-        displayFormat: DisplayFormat,
         type?: string
     ): VarObjType {
         let vars = this.variableMap.get(this.getKey(frameRef, depth));
@@ -107,7 +104,6 @@ export class VarManager {
             type: varCreateResponse.type,
             isVar,
             isChild,
-            displayFormat,
             varType: type ? type : 'local',
         };
         vars.push(varobj);
@@ -168,8 +164,7 @@ export class VarManager {
                     varobj.expression,
                     varobj.isVar,
                     varobj.isChild,
-                    createResponse,
-                    varobj.displayFormat
+                    createResponse
                 );
             }
         }

--- a/src/varManager.ts
+++ b/src/varManager.ts
@@ -1,7 +1,12 @@
 import { IGDBBackend } from './types/gdb';
-import { MIVarCreateResponse } from './mi/var';
-import { sendVarCreate, sendVarDelete, sendVarUpdate } from './mi/var';
 import { FrameReference } from './types/session';
+import {
+    MIVarCreateResponse,
+    DisplayFormat,
+    sendVarCreate,
+    sendVarDelete,
+    sendVarUpdate,
+} from './mi/var';
 
 export interface VarObjType {
     varname: string;
@@ -13,6 +18,7 @@ export interface VarObjType {
     isVar: boolean;
     isChild: boolean;
     varType: string;
+    displayFormat: DisplayFormat;
 }
 
 export class VarManager {
@@ -84,6 +90,7 @@ export class VarManager {
         isVar: boolean,
         isChild: boolean,
         varCreateResponse: MIVarCreateResponse,
+        displayFormat: DisplayFormat,
         type?: string
     ): VarObjType {
         let vars = this.variableMap.get(this.getKey(frameRef, depth));
@@ -100,6 +107,7 @@ export class VarManager {
             type: varCreateResponse.type,
             isVar,
             isChild,
+            displayFormat,
             varType: type ? type : 'local',
         };
         vars.push(varobj);
@@ -160,7 +168,8 @@ export class VarManager {
                     varobj.expression,
                     varobj.isVar,
                     varobj.isChild,
-                    createResponse
+                    createResponse,
+                    varobj.displayFormat
                 );
             }
         }


### PR DESCRIPTION
Should solve https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210

# New implementation:

1. Updated the function `sendVarSetFormatToHex` to make it more generic to different value formats. Also changed the return type from void to string, to retrieve the actual value.
2. In the `evaluate` request, added support for setting value format for expressions
3. Added a new property `displayFormat` to `VarObjType`

Now users can provide format specifiers to their expressions. It can be 

```
,x  -> hex
,o  -> octal
,b -> binary
,d -> decimal
,z -> zero-hexadecimal
``` 


# Old implementation:

Supporting value formatting in evaluate requests.

1. Updated function sendVarSetFormatToHex to return string that includes updated value in hex instead of void
5. Checking on `format` property of evaluate request arguments before sending result

# Notes

- the feature only works with primitive data types so far