### PR TITLE
Remove redundant sendVarDelete call that throws an error

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2498,9 +2498,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             depth,
                             varobj.varname
                         );
-                        await mi.sendVarDelete(gdb, {
-                            varname: varobj.varname,
-                        });
                         const varCreateResponse = await mi.sendVarCreate(gdb, {
                             expression,
                             frameRef,

--- a/src/integration-tests/doEvaluateRequest.spec.ts
+++ b/src/integration-tests/doEvaluateRequest.spec.ts
@@ -1,0 +1,243 @@
+/*********************************************************************
+ * Copyright (c) 2026 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import 'mocha';
+import { expect } from 'chai';
+
+import * as sinon from 'sinon';
+import { DebugProtocol } from '@vscode/debugprotocol';
+
+import { GDBDebugSessionBase } from '../gdb/GDBDebugSessionBase';
+import * as miVar from '../mi/var';
+
+class TestableSession extends GDBDebugSessionBase {
+    constructor(backendFactory: any) {
+        super(backendFactory);
+    }
+
+    public async callDoEvaluateRequest(
+        response: DebugProtocol.EvaluateResponse,
+        args: DebugProtocol.EvaluateArguments,
+        alwaysAllowCliCommand: boolean
+    ) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (this as any).doEvaluateRequest(
+            response,
+            args,
+            alwaysAllowCliCommand
+        );
+    }
+}
+
+function makeEvaluateResponse(): DebugProtocol.EvaluateResponse {
+    return {
+        type: 'response',
+        seq: 0,
+        request_seq: 1,
+        success: true,
+        command: 'evaluate',
+        body: {} as any,
+    } as DebugProtocol.EvaluateResponse;
+}
+
+describe('doEvaluateRequest - MI var deletion single-owner invariant', function () {
+    let session: TestableSession;
+    let sandbox: sinon.SinonSandbox;
+
+    let gdb: any;
+    let varManager: {
+        getVar: sinon.SinonStub;
+        addVar: sinon.SinonStub;
+        removeVar: sinon.SinonStub;
+    };
+    let backendFactory: any;
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+
+        varManager = {
+            getVar: sandbox.stub(),
+            addVar: sandbox.stub(),
+            removeVar: sandbox.stub(),
+        };
+
+        gdb = { varManager };
+
+        backendFactory = {
+            create: sandbox.stub().returns(gdb),
+            dispose: sandbox.stub(),
+        };
+
+        session = new TestableSession(backendFactory);
+        (session as any).gdb = gdb;
+
+        // Make frameId resolvable
+        (session as any).frameHandles = new Map<number, any>([
+            [111, { id: 'f1' }],
+            [222, { id: 'f1' }],
+            [333, { id: 'f1' }],
+            [444, { id: 'f1' }],
+        ]);
+
+        sandbox.stub(session as any, 'canRequestProceed').returns(true);
+        sandbox
+            .stub(session as any, 'getFrameContext')
+            .resolves([gdb, { id: 'f1' }, 0]);
+        sandbox.stub(session as any, 'sendResponse').callsFake(() => {});
+        sandbox.stub(session as any, 'sendErrorResponse').callsFake(() => {});
+
+        // MI stubs
+        sandbox.stub(miVar, 'sendVarCreate');
+        sandbox.stub(miVar, 'sendVarUpdate');
+        sandbox.stub(miVar, 'sendVarDelete');
+
+        /*
+         * Simulate the REAL contract:
+         * removeVar() is the SINGLE OWNER of MI var deletion.
+         *
+         * This is what allows the tests to:
+         *  - FAIL if doEvaluateRequest also deletes (duplicate delete)
+         *  - FAIL if removeVar stops deleting
+         *  - PASS only when exactly ONE delete occurs
+         */
+        varManager.removeVar = sandbox
+            .stub()
+            .callsFake(async (_frameRef, _depth, varname: string) => {
+                await miVar.sendVarDelete(gdb, { varname });
+            });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('out-of-scope: MI var must be deleted exactly once and recreated', async function () {
+        varManager.getVar.returns({
+            varname: 'v1',
+            numchild: '0',
+            type: 'int',
+            value: '1',
+        });
+
+        (miVar.sendVarUpdate as sinon.SinonStub).resolves({
+            changelist: [{ in_scope: 'false', name: 'v1', value: '?' }],
+        });
+
+        (miVar.sendVarCreate as sinon.SinonStub).resolves({});
+        varManager.addVar.returns({
+            varname: 'v2',
+            numchild: '0',
+            type: 'int',
+            value: '2',
+        });
+
+        const response = makeEvaluateResponse();
+        const args: DebugProtocol.EvaluateArguments = {
+            expression: 'x',
+            frameId: 111,
+            context: 'watch',
+        };
+
+        await session.callDoEvaluateRequest(response, args, false);
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must occur exactly once'
+        ).to.equal(1);
+    });
+
+    it('out-of-scope (another frame): MI var must be deleted exactly once and recreated', async function () {
+        varManager.getVar.returns({
+            varname: 'v1',
+            numchild: '0',
+            type: 'int',
+            value: '1',
+        });
+
+        (miVar.sendVarUpdate as sinon.SinonStub).resolves({
+            changelist: [{ in_scope: 'false', name: 'v1', value: '?' }],
+        });
+
+        (miVar.sendVarCreate as sinon.SinonStub).resolves({});
+        varManager.addVar.returns({
+            varname: 'v3',
+            numchild: '0',
+            type: 'int',
+            value: '3',
+        });
+
+        const response = makeEvaluateResponse();
+        const args: DebugProtocol.EvaluateArguments = {
+            expression: 'x',
+            frameId: 222,
+            context: 'watch',
+        };
+
+        await session.callDoEvaluateRequest(response, args, false);
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must occur exactly once'
+        ).to.equal(1);
+    });
+
+    it('in-scope: value updated without MI var deletion', async function () {
+        varManager.getVar.returns({
+            varname: 'v1',
+            numchild: '0',
+            type: 'int',
+            value: '10',
+        });
+
+        (miVar.sendVarUpdate as sinon.SinonStub).resolves({
+            changelist: [{ in_scope: 'true', name: 'v1', value: '99' }],
+        });
+
+        const response = makeEvaluateResponse();
+        const args: DebugProtocol.EvaluateArguments = {
+            expression: 'x',
+            frameId: 333,
+            context: 'watch',
+        };
+
+        await session.callDoEvaluateRequest(response, args, false);
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must not occur for in-scope updates'
+        ).to.equal(0);
+    });
+
+    it('no varobj: create new variable without MI var deletion', async function () {
+        varManager.getVar.returns(undefined);
+
+        (miVar.sendVarCreate as sinon.SinonStub).resolves({});
+        varManager.addVar.returns({
+            varname: 'v-new',
+            numchild: '0',
+            type: 'int',
+            value: '111',
+        });
+
+        const response = makeEvaluateResponse();
+        const args: DebugProtocol.EvaluateArguments = {
+            expression: 'y',
+            frameId: 444,
+            context: 'watch',
+        };
+
+        await session.callDoEvaluateRequest(response, args, false);
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must not occur when creating new variables'
+        ).to.equal(0);
+    });
+});

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -463,3 +463,119 @@ describe('evaluate request global variables', function () {
         });
     });
 });
+
+describe('evaluate request - watch local variable across lexical scope transition', function () {
+    let dc: CdtDebugClient;
+    let scope: Scope;
+
+    const DEBUG = false;
+    const program = path.join(testProgramsDir, 'watch_local_scope_transition');
+    const src = path.join(testProgramsDir, 'watch_local_scope_transition.c');
+    const lineTags = {
+        FIRST_SCOPE: 0,
+        SECOND_SCOPE: 0,
+    };
+
+    before(function () {
+        resolveLineTagLocations(src, lineTags);
+        if (DEBUG) {
+            console.log('FIRST_SCOPE line:', lineTags.FIRST_SCOPE);
+            console.log('SECOND_SCOPE line:', lineTags.SECOND_SCOPE);
+        }
+    });
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach();
+
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, {
+                program,
+            })
+        );
+
+        await dc.setBreakpointsRequest({
+            source: { path: src },
+            breakpoints: [
+                { line: lineTags.FIRST_SCOPE },
+                { line: lineTags.SECOND_SCOPE },
+            ],
+        });
+
+        await Promise.all([
+            dc.waitForEvent('stopped'),
+            dc.configurationDoneRequest(),
+        ]);
+
+        scope = await getScopes(dc);
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    it('should reevaluate a watched local variable when a same-named local is recreated in a new scope', async function () {
+        // Evaluate "x" in the first lexical scope and cache/reuse the varobj.
+        // With the buggy implementation, when that varobj later goes out of scope,
+        // doEvaluateRequest() deletes it twice:
+        //   1) indirectly via varManager.removeVar()
+        //   2) directly via an extra mi.sendVarDelete()
+        //
+        // The second delete triggers the GDB/MI error "Variable object not found",
+        // causing watch reevaluation to fail instead of recreating the varobj for
+        // the new in-scope local variable in the second block.
+
+        const first = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'x',
+            frameId: scope.frame.id,
+        });
+        if (DEBUG) {
+            console.log('first watch result:', first.body.result);
+        }
+        expect(first.body.result).to.equal('1');
+
+        // Re-evaluate once more in the first scope to ensure the existing varobj
+        // path is exercised before transitioning to the next scope.
+        const firstAgain = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'x',
+            frameId: scope.frame.id,
+        });
+        if (DEBUG) {
+            console.log('firstAgain watch result:', firstAgain.body.result);
+        }
+        expect(firstAgain.body.result).to.equal('1');
+
+        // Continue to the second block where a new local variable "x" is created.
+        await Promise.all([
+            dc.waitForEvent('stopped'),
+            dc.continueRequest({ threadId: scope.thread.id }),
+        ]);
+
+        scope = await getScopes(dc);
+
+        try {
+            const second = await dc.evaluateRequest({
+                context: 'watch',
+                expression: 'x',
+                frameId: scope.frame.id,
+            });
+
+            if (DEBUG) {
+                console.log('second watch result:', second.body.result);
+            }
+            expect(second.body.result).to.equal('2');
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (DEBUG) {
+                console.log(
+                    'watch reevaluation failed after scope transition:',
+                    msg
+                );
+            }
+            expect.fail(
+                `Expected watched expression "x" to reevaluate to "2" in the second scope, but evaluation failed: ${msg}`
+            );
+        }
+    });
+});

--- a/src/integration-tests/test-programs/.gitignore
+++ b/src/integration-tests/test-programs/.gitignore
@@ -8,6 +8,7 @@ mem
 vars
 vars_env
 vars_globals
+watch_local_scope_transition
 segv
 loopforever
 MultiThread

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -1,4 +1,4 @@
-BINS = empty empty\ space evaluate vars vars_cpp vars_env vars_globals mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr bug275-测试 cwd.exe stepping
+BINS = empty empty\ space evaluate vars vars_cpp vars_env vars_globals mem segv count disassemble functions loopforever MultiThread MultiThreadRunControl stderr bug275-测试 cwd.exe stepping watch_local_scope_transition
 
 .PHONY: all
 all: $(BINS)
@@ -90,6 +90,9 @@ stderr: stderr.o
 	$(LINK)
 
 stepping: stepping.o
+	$(LINK)
+
+watch_local_scope_transition: watch_local_scope_transition.o
 	$(LINK)
 
 %.o: %.c

--- a/src/integration-tests/test-programs/watch_local_scope_transition.c
+++ b/src/integration-tests/test-programs/watch_local_scope_transition.c
@@ -1,0 +1,21 @@
+// watch_local_scope_transition.c
+// This program is intentionally minimal and designed to trigger
+// GDB MI var-object invalidation when stepping, even though the
+// variable remains lexically in scope.
+
+#include <stdio.h>
+
+int main(void)
+{
+    {
+        int x = 1;
+        printf("%d\n", x);   // FIRST_SCOPE
+    }
+
+    {
+        int x = 2;
+        printf("%d\n", x);   // SECOND_SCOPE
+    }
+
+    return 0;
+}

--- a/src/integration-tests/varManager.removeVar.spec.ts
+++ b/src/integration-tests/varManager.removeVar.spec.ts
@@ -1,0 +1,122 @@
+/*********************************************************************
+ * Copyright (c) 2026 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import 'mocha';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import * as miVar from '../mi/var';
+import { VarManager } from '../varManager';
+
+describe('VarManager.removeVar - MI deletion contract', function () {
+    let sandbox: sinon.SinonSandbox;
+    let varManager: VarManager;
+    let gdb: any;
+
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+        gdb = {};
+
+        // Create real VarManager instance
+        varManager = new VarManager(gdb);
+
+        // Stub MI delete
+        sandbox.stub(miVar, 'sendVarDelete').resolves(undefined);
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('deletes MI var exactly once when removing a variable', async function () {
+        const frameRef = {
+            threadId: 1,
+            frameId: 0,
+        };
+        const depth = 0;
+
+        // Minimal VarObjType
+        const varObj = {
+            varname: 'v1',
+            children: [],
+        } as any;
+
+        // Simulate internal state
+        const key = (varManager as any).getKey(frameRef, depth);
+        (varManager as any).variableMap.set(key, [varObj]);
+
+        await varManager.removeVar(frameRef, depth, 'v1');
+
+        // Core invariant
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var must be deleted exactly once'
+        ).to.equal(1);
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).firstCall.args[1]
+        ).to.deep.equal({ varname: 'v1' });
+    });
+
+    it('recursively deletes children MI vars when removing a parent', async function () {
+        const frameRef = {
+            threadId: 1,
+            frameId: 0,
+        };
+        const depth = 0;
+
+        const child1 = { varname: 'c1', children: [] } as any;
+        const child2 = { varname: 'c2', children: [] } as any;
+
+        const parent = {
+            varname: 'p',
+            children: [child1, child2],
+        } as any;
+
+        const key = (varManager as any).getKey(frameRef, depth);
+        (varManager as any).variableMap.set(key, [parent, child1, child2]);
+
+        await varManager.removeVar(frameRef, depth, 'p');
+
+        // Parent + 2 children
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must occur for parent and all children'
+        ).to.equal(3);
+
+        sinon.assert.calledWith(miVar.sendVarDelete as sinon.SinonStub, gdb, {
+            varname: 'p',
+        });
+        sinon.assert.calledWith(miVar.sendVarDelete as sinon.SinonStub, gdb, {
+            varname: 'c1',
+        });
+        sinon.assert.calledWith(miVar.sendVarDelete as sinon.SinonStub, gdb, {
+            varname: 'c2',
+        });
+    });
+
+    it('does nothing if var name does not exist', async function () {
+        const frameRef = {
+            threadId: 1,
+            frameId: 0,
+        };
+        const depth = 0;
+
+        const key = (varManager as any).getKey(frameRef, depth);
+        (varManager as any).variableMap.set(key, []);
+
+        await varManager.removeVar(frameRef, depth, 'ghost');
+
+        expect(
+            (miVar.sendVarDelete as sinon.SinonStub).callCount,
+            'MI var delete must not occur for non-existing var'
+        ).to.equal(0);
+    });
+});


### PR DESCRIPTION
_this is the updated description and summary, as this change was progressed the design and implementation changed substantially. See collapsed section below for original description._

This sendVarDelete is rarely reachable, generally only reachable when the same variable name is used in two different scopes within the same method. See use of `x` variable in
src/integration-tests/test-programs/watch_local_scope_transition.c for an example.

When debugging such code, and the `x` was in the watch window, the now removed sendVarDelete would run, but the var was already deleted by the varManager.removeVar on the line above. So the sendVarDelete would generate an exception, causing the `x` not to be evaluated.

Included in this change is a test that demonstrates the use case, the new test `evaluate request - watch local variable across lexical scope transition` in evaluate.spec.ts.

<details><summary>Original message</summary>
<p>

Summary: Improvement/wrap send var delete in try/catch after remove var in do evaluate request



*For ECA reasons, this is a continuation of https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/509*

**Background:** removeVar(...) called sendVarDelete(...) inside itself.
In case of doEvaluateRequest(...) method, it will throw "object not found" error when calling sendVarDelete(...) after removeVar(...).

**Solution:** add try/catch to safely wrap the sendVarDelete(...) to swallow the "object not found" error.
Other errors still be catch in catch (err) block in the end of doEvaluateRequest(...) as currently.

**Reason of NOT removing sendVarDelete(...) in doEvaluateRequest(...):** 
1/ In future, if a person removes sendVarDelete(...) inside removeVar(...) -> sendVarDelete(...) still need to be called after removeVar(...) - same as current development.
2/ Why I did not remove sendVarDelete(...) inside removeVar(...) : because removeVar(...) is used at other place , also maybe used in third party code. If I change removeVar(...) it will impact their implementation.



</p>
</details> 
