### PR TITLE
Using detach command for disconnection

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -835,7 +835,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
 
     protected async doDisconnectRequest(
         gdbServerTimeout: number,
-        sendTerminate?: boolean
+        terminateDebuggee?: boolean
     ): Promise<void> {
         await this.setSessionState(SessionState.EXITING);
 
@@ -854,12 +854,19 @@ export class GDBTargetDebugSession extends GDBDebugSession {
                     this.targetType === 'remote' &&
                     (!this.launchGdbServer || isProcessActive(this.gdbserver))
                 ) {
-                    // Need to pause first, then disconnect and exit.
-                    await this.pauseIfNeeded(true);
-                    if (this.auxGdb?.isActive()) {
-                        await this.auxGdb.sendCommand('disconnect');
+                    let command = 'detach';
+                    if (terminateDebuggee !== false) {
+                        // Need to pause first, then disconnect and exit.
+                        await this.pauseIfNeeded(true);
+                        command = 'disconnect';
+                    } else if (this.gdb.isNonStopMode() === false) {
+                        // Need to pause before detach if it is all-stop mode
+                        await this.pauseIfNeeded(true);
                     }
-                    await this.gdb.sendCommand('disconnect');
+                    if (this.auxGdb?.isActive()) {
+                        await this.auxGdb.sendCommand(command);
+                    }
+                    await this.gdb.sendCommand(command);
                 }
 
                 if (this.auxGdb?.isActive()) {
@@ -894,7 +901,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
             }
         }
 
-        if (sendTerminate) {
+        if (terminateDebuggee) {
             this.sendEvent(new TerminatedEvent());
         }
     }
@@ -905,10 +912,10 @@ export class GDBTargetDebugSession extends GDBDebugSession {
      */
     protected async disconnectRequest(
         response: DebugProtocol.DisconnectResponse,
-        _args: DebugProtocol.DisconnectArguments
+        args: DebugProtocol.DisconnectArguments
     ): Promise<void> {
         try {
-            await this.doDisconnectRequest(0);
+            await this.doDisconnectRequest(0, args?.terminateDebuggee);
             if (this.sessionInfo.disconnectError) {
                 this.sendErrorResponse(
                     response,

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -428,6 +428,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.supportsInstructionBreakpoints = true;
         response.body.supportsTerminateRequest = this.isRemote;
         response.body.supportsDataBreakpoints = true;
+        response.body.supportTerminateDebuggee = this.isRemote;
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
     }

--- a/src/integration-tests/launchRemote.spec.ts
+++ b/src/integration-tests/launchRemote.spec.ts
@@ -23,6 +23,7 @@ import {
 } from './utils';
 import { expect } from 'chai';
 import * as os from 'os';
+import { DebugProtocol } from '@vscode/debugprotocol';
 
 describe('launch remote', function () {
     let dc: CdtDebugClient;
@@ -324,5 +325,21 @@ describe('launch remote', function () {
             initPos,
             'preConnectCommands should execute before initCommands'
         );
+    });
+
+    it('disconnect from launch but not terminate debuggee', async function () {
+        const args = {
+            program: emptyProgram,
+            target: {
+                type: 'remote',
+            } as TargetLaunchArguments,
+        } as TargetLaunchRequestArguments;
+        await dc.launchRequest(fillDefaults(this.test, args));
+
+        const detachEvent = dc.waitForOutputEvent('log', 'detach\n');
+        await dc.disconnectRequest({
+            terminateDebuggee: false,
+        } as DebugProtocol.DisconnectArguments);
+        await detachEvent;
     });
 });


### PR DESCRIPTION
In remote debugging, both **terminate** and **disconnect** actions currently result in the target being halted.
This change proposes using the **detach** command on disconnect, allowing the target to continue running after disconnection by properly handling the detach message in the GDB server.