### PR TITLE
Send invalidate event on radix change

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -87,6 +87,12 @@ interface StreamOutput {
     category: string;
 }
 
+// Interface for notify data of cmd-param-changed  
+interface CmdParamChangedNotifyData {
+    param: string;
+    value: string;
+}
+
 // Interface for a pending pause request, used with pauseIfRunning() logic
 interface PendingPauseRequest {
     threadId: number | undefined; // All threads if undefined
@@ -3005,7 +3011,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
     }
 
-    private handleCmdParamChanged(notifyData: any) {
+    private handleCmdParamChanged(notifyData: CmdParamChangedNotifyData) {
         switch (notifyData.param) {
             case 'output-radix':
                 this.sendEvent(new InvalidatedEvent(['variables']));

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -425,24 +425,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
     }
-    private switchTooManyBreakpointsMessage(): StreamOutput {
-        const TooManyBreakpointsOutputToError =
+
+    private switchOutputToError(input: string, category: string): StreamOutput {
+        const outputToError =
             'HW breakpoint limit reached, reduce set breakpoints';
-        const returnPair: StreamOutput = {
-            output: TooManyBreakpointsOutputToError,
-            category: 'stderr',
-        };
+        const returnPair: StreamOutput = input.startsWith(
+            'Cannot insert hardware breakpoint'
+        )
+            ? { output: outputToError, category: 'stderr' }
+            : { output: input, category: category };
         return returnPair;
-    }
-    private actOnGdbOutput(input: string): void | StreamOutput {
-        // When a new output radix is set, VScode needs to reread all information again. Hence, the adapter sends an invalidate event
-        if (input.startsWith('Output radix now set')) {
-            this.sendEvent(new InvalidatedEvent());
-            return;
-        }
-        if (input.startsWith('Cannot insert hardware breakpoint')) {
-            return this.switchTooManyBreakpointsMessage();
-        }
     }
 
     protected async setupCommonLoggerAndBackends(
@@ -468,17 +460,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         gdb.on('consoleStreamOutput', (output, category) => {
-            const messageToPrint = this.actOnGdbOutput(output);
-            if (messageToPrint) {
-                this.sendEvent(
-                    new OutputEvent(
-                        messageToPrint.output,
-                        messageToPrint.category
-                    )
-                );
-                return;
-            }
-            this.sendEvent(new OutputEvent(output, category));
+            const messageToPrint = this.switchOutputToError(output, category);
+            this.sendEvent(
+                new OutputEvent(messageToPrint.output, messageToPrint.category)
+            );
         });
 
         gdb.on('execAsync', (resultClass, resultData) =>
@@ -3020,6 +3005,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
     }
 
+    private handleCmdParamChanged(notifyData: any) {
+        switch (notifyData.param) {
+            case 'output-radix':
+                this.sendEvent(new InvalidatedEvent(['variables']));
+                break;
+            default:
+                break;
+        }
+    }
+
     protected handleGDBNotify(notifyClass: string, notifyData: any) {
         switch (notifyClass) {
             case 'thread-created':
@@ -3106,7 +3101,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 break;
             case 'cmd-param-changed':
-                // Known unhandled notifies
+                this.handleCmdParamChanged(notifyData);
                 break;
             default:
                 logger.warn(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -468,7 +468,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         gdb.on('consoleStreamOutput', (output, category) => {
-            const messageToPrint = this.actOnGdbOutput(output, category);
+            const messageToPrint = this.actOnGdbOutput(output);
             if (messageToPrint) {
                 this.sendEvent(
                     new OutputEvent(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -425,20 +425,27 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
     }
-
-    private actOnGdbOutput(input: string, category: string): StreamOutput {
-        // When a new output radix is set, VScode needs to reread all information again. Hence, the adapter sends an invalidate event
-        if (input.startsWith('Output radix now set')){
-            this.sendEvent(new InvalidatedEvent());
-        }
+    private switchTooManyBreakpointsMessage(): StreamOutput {
         const TooManyBreakpointsOutputToError =
             'HW breakpoint limit reached, reduce set breakpoints';
-        const returnPair: StreamOutput = input.startsWith(
-            'Cannot insert hardware breakpoint'
-        )
-            ? { output: TooManyBreakpointsOutputToError, category: 'stderr' }
-            : { output: input, category: category };
+        const returnPair: StreamOutput = {
+            output: TooManyBreakpointsOutputToError,
+            category: 'stderr',
+        };
         return returnPair;
+    }
+    private actOnGdbOutput(
+        input: string,
+        category: string
+    ): void | StreamOutput {
+        // When a new output radix is set, VScode needs to reread all information again. Hence, the adapter sends an invalidate event
+        if (input.startsWith('Output radix now set')) {
+            this.sendEvent(new InvalidatedEvent());
+            return;
+        }
+        if (input.startsWith('Cannot insert hardware breakpoint')) {
+            return this.switchTooManyBreakpointsMessage();
+        }
     }
 
     protected async setupCommonLoggerAndBackends(
@@ -465,9 +472,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
         gdb.on('consoleStreamOutput', (output, category) => {
             const messageToPrint = this.actOnGdbOutput(output, category);
-            this.sendEvent(
-                new OutputEvent(messageToPrint.output, messageToPrint.category)
-            );
+            if (messageToPrint) {
+                this.sendEvent(
+                    new OutputEvent(
+                        messageToPrint.output,
+                        messageToPrint.category
+                    )
+                );
+            }
         });
 
         gdb.on('execAsync', (resultClass, resultData) =>

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -87,7 +87,7 @@ interface StreamOutput {
     category: string;
 }
 
-// Interface for notify data of cmd-param-changed  
+// Interface for notify data of cmd-param-changed
 interface CmdParamChangedNotifyData {
     param: string;
     value: string;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -434,10 +434,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         };
         return returnPair;
     }
-    private actOnGdbOutput(
-        input: string,
-        category: string
-    ): void | StreamOutput {
+    private actOnGdbOutput(input: string): void | StreamOutput {
         // When a new output radix is set, VScode needs to reread all information again. Hence, the adapter sends an invalidate event
         if (input.startsWith('Output radix now set')) {
             this.sendEvent(new InvalidatedEvent());
@@ -479,7 +476,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         messageToPrint.category
                     )
                 );
+                return;
             }
+            this.sendEvent(new OutputEvent(output, category));
         });
 
         gdb.on('execAsync', (resultClass, resultData) =>

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -14,6 +14,7 @@ import {
     BreakpointEvent,
     Handles,
     InitializedEvent,
+    InvalidatedEvent,
     Logger,
     logger,
     LoggingDebugSession,
@@ -425,13 +426,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    private switchOutputToError(input: string, category: string): StreamOutput {
-        const outputToError =
+    private actOnGdbOutput(input: string, category: string): StreamOutput {
+        // When a new output radix is set, VScode needs to reread all information again. Hence, the adapter sends an invalidate event
+        if (input.startsWith('Output radix now set')){
+            this.sendEvent(new InvalidatedEvent());
+        }
+        const TooManyBreakpointsOutputToError =
             'HW breakpoint limit reached, reduce set breakpoints';
         const returnPair: StreamOutput = input.startsWith(
             'Cannot insert hardware breakpoint'
         )
-            ? { output: outputToError, category: 'stderr' }
+            ? { output: TooManyBreakpointsOutputToError, category: 'stderr' }
             : { output: input, category: category };
         return returnPair;
     }
@@ -459,7 +464,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         gdb.on('consoleStreamOutput', (output, category) => {
-            const messageToPrint = this.switchOutputToError(output, category);
+            const messageToPrint = this.actOnGdbOutput(output, category);
             this.sendEvent(
                 new OutputEvent(messageToPrint.output, messageToPrint.category)
             );

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -167,7 +167,7 @@ describe('evaluate request', function () {
         });
         expect(res2.body.result).eq('10');
     });
-    
+
     it('should be able to use GDB command', async function () {
         const res1 = await dc.evaluateRequest({
             context: 'repl',
@@ -196,11 +196,11 @@ describe('evaluate request', function () {
 
         expect(err.message).eq('Undefined MI command: a');
     });
-    
+
     it('should send invalidate event when changing global radix through evaluate request', async function () {
         if (os.platform() === 'win32' || !(isRemoteTest && gdbAsync)) {
-                    this.skip();
-                }
+            this.skip();
+        }
         const event = dc.waitForEvent('invalidated');
         await dc.evaluateRequest({
             context: 'repl',

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -13,6 +13,7 @@ import { CdtDebugClient } from './debugClient';
 import {
     expectRejection,
     fillDefaults,
+    gdbAsync,
     getScopes,
     isRemoteTest,
     resolveLineTagLocations,
@@ -21,6 +22,7 @@ import {
     testProgramsDir,
 } from './utils';
 import { expect } from 'chai';
+import * as os from 'os';
 
 describe('evaluate request', function () {
     let dc: CdtDebugClient;
@@ -165,6 +167,7 @@ describe('evaluate request', function () {
         });
         expect(res2.body.result).eq('10');
     });
+    
     it('should be able to use GDB command', async function () {
         const res1 = await dc.evaluateRequest({
             context: 'repl',
@@ -181,6 +184,7 @@ describe('evaluate request', function () {
 
         expect(res2.body.result).eq('\r');
     });
+
     it('should reject entering an invalid MI command', async function () {
         const err = await expectRejection(
             dc.evaluateRequest({
@@ -192,11 +196,15 @@ describe('evaluate request', function () {
 
         expect(err.message).eq('Undefined MI command: a');
     });
+    
     it('should send invalidate event when changing global radix through evaluate request', async function () {
+        if (os.platform() === 'win32' || !(isRemoteTest && gdbAsync)) {
+                    this.skip();
+                }
         const event = dc.waitForEvent('invalidated');
         await dc.evaluateRequest({
             context: 'repl',
-            expression: '> set output-radix 10',
+            expression: '> set output-radix 16',
             frameId: scope.frame.id,
         });
         const invalidatedEvent = await event;

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -22,7 +22,6 @@ import {
     testProgramsDir,
 } from './utils';
 import { expect } from 'chai';
-import * as os from 'os';
 
 describe('evaluate request', function () {
     let dc: CdtDebugClient;

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -192,6 +192,16 @@ describe('evaluate request', function () {
 
         expect(err.message).eq('Undefined MI command: a');
     });
+    it('should send invalidate event when changing global radix through evaluate request', async function () {
+        const event = dc.waitForEvent('invalidated');
+        await dc.evaluateRequest({
+            context: 'repl',
+            expression: '> set output-radix 10',
+            frameId: scope.frame.id,
+        });
+        const invalidatedEvent = await event;
+        expect(invalidatedEvent).to.be.not.undefined;
+    });
 });
 
 describe('evaluate request global variables', function () {

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -198,7 +198,7 @@ describe('evaluate request', function () {
     });
 
     it('should send invalidate event when changing global radix through evaluate request', async function () {
-        if (os.platform() === 'win32' || !(isRemoteTest && gdbAsync)) {
+        if (!(isRemoteTest && gdbAsync)) {
             this.skip();
         }
         const event = dc.waitForEvent('invalidated');


### PR DESCRIPTION
should fulfill https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/207

Background:
When changing the debugee's global radix, values don't immediately update on VSCode. As a workaround users had to step or change vscode state somehow.

Solution:
Whenever a global radix is set, GDB sends the following message via the console "Output radix now set to <radix>". By tapping on GDB messages to the system, the adapter would send an `invalidated` event to prompt clients to refresh the system.