### PR TITLE
Unify to Arm Limited in copyright headers

### DIFF
--- a/src/constants/gdb.ts
+++ b/src/constants/gdb.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd. and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/events/stoppedEvent.ts
+++ b/src/events/stoppedEvent.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Arm Ltd. and others
+ * Copyright (c) 2019 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/gdb/errors.ts
+++ b/src/gdb/errors.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd. and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/auxiliaryGdb.spec.ts
+++ b/src/integration-tests/auxiliaryGdb.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Arm and others
+ * Copyright (c) 2019 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/custom-reset.spec.ts
+++ b/src/integration-tests/custom-reset.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/functionBreakpoints.spec.ts
+++ b/src/integration-tests/functionBreakpoints.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Arm and others
+ * Copyright (c) 2019 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/lateAsyncErrorsRemote.spec.ts
+++ b/src/integration-tests/lateAsyncErrorsRemote.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/launchRemoteUnexpectedExit.spec.ts
+++ b/src/integration-tests/launchRemoteUnexpectedExit.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd., Kichwa Coders and others
+ * Copyright (c) 2025 Arm Limited, Kichwa Coders and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/logpoints.spec.ts
+++ b/src/integration-tests/logpoints.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Arm and others
+ * Copyright (c) 2019 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/mocks/debugAdapters/auxiliaryGdb.ts
+++ b/src/integration-tests/mocks/debugAdapters/auxiliaryGdb.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/integration-tests/stepout.spec.ts
+++ b/src/integration-tests/stepout.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Arm and others
+ * Copyright (c) 2019 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/namedLogger.ts
+++ b/src/namedLogger.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd. and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/util/processes.ts
+++ b/src/util/processes.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd. and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
This PR unifies different forms of calling out Arm ("Arm", "Arm Ltd.", "Arm Ltd", "Arm Limited") in copyright headers to "Arm Limited" for easier reference.