### PR TITLE
Use Node 24 in publish job to fix npm self-upgrade crash

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Update npm (OIDC/provenance support)
         run: npm i -g npm@latest


### PR DESCRIPTION
The `Publish Package to NPM` job has been failing in the `Update npm (OIDC/provenance support)` step because `npm i -g npm@latest` cannot self-upgrade from the npm 10.9.x bundled with Node 22.22.2 (upstream bug [npm/cli#9151](https://github.com/npm/cli/issues/9151)). This blocked the v1.8.0 release from reaching npm.

This PR bumps **only the publish job** to Node 24, whose bundled npm already includes the upstream fix from [npm/cli#9152](https://github.com/npm/cli/pull/9152). CI's Build & Test jobs stay on Node 22 — the integration test matrix (Ubuntu + Windows, GDB breakpoints, async/non-stop, native PTY tests, serialport native builds) is not touched.

The publish job runs only `yarn` (which triggers `prepublish: yarn build` → `tsc` + `esbuild`) and `npm publish`. No tests, no `nativebuild` at publish time. The published tarball is JS produced by tsc/esbuild plus `.cc/.h` sources — runtime-Node-version-independent — so consumers are unaffected by the build host's Node version.

A v1.8.1 release preparation PR will follow once this is merged.

Fixes #530