### PR TITLE
v1.8.1 Release Preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.1
+
+- Fixes [`#530`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/530): Bump publish job to Node 24 to work around an npm self-upgrade crash that prevented 1.8.0 from being published to npm.
+
 ## 1.8.0
 
 - Implements [`#506`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/506): Support value formatting in expressions with `,<type>` (where `<type>` is one of `x` (hex), `d` (dec), `o` (oct), `t`/`b` (bin), `z` (zero-padded hex)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-adapter",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "gdb adapter implementing the debug adapter protocol",
   "main": "dist/index.js",
   "browser": "dist/browser/web.js",


### PR DESCRIPTION
- Fixes [`#530`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/530): Bump publish job to Node 24 to work around an npm self-upgrade crash that prevented 1.8.0 from being published to npm (workflow fix landed in #531).

There are no code changes from 1.8.0 — this release is solely to re-publish 1.8.0 to npm under the 1.8.1 version.