### PR TITLE
Handle memory notifications

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3169,12 +3169,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.handleCmdParamChanged(notifyData);
                 break;
             case 'memory-changed': {
-                const length = isNaN(notifyData.len) ? 0 : parseInt(notifyData.len, 10);
-                const memoryEvent = new MemoryEvent(
-                    notifyData.addr,
-                    0,
-                    length
-                );
+                const length = isNaN(notifyData.len)
+                    ? 0
+                    : parseInt(notifyData.len, 10);
+                const memoryEvent = new MemoryEvent(notifyData.addr, 0, length);
                 this.sendEvent(memoryEvent);
                 break;
             }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3168,14 +3168,15 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             case 'cmd-param-changed':
                 this.handleCmdParamChanged(notifyData);
                 break;
-            case 'memory-changed':
+            case 'memory-changed': {
                 const memoryEvent = new MemoryEvent(
                     notifyData.addr,
                     0,
                     parseInt(notifyData.len)
                 );
                 this.sendEvent(memoryEvent);
-                    break;
+                break;
+            }
             default:
                 logger.warn(
                     `GDB unhandled notify: ${notifyClass}: ${JSON.stringify(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3169,10 +3169,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.handleCmdParamChanged(notifyData);
                 break;
             case 'memory-changed': {
+                const length = isNaN(notifyData.len) ? 0 : parseInt(notifyData.len, 10);
                 const memoryEvent = new MemoryEvent(
                     notifyData.addr,
                     0,
-                    parseInt(notifyData.len)
+                    length
                 );
                 this.sendEvent(memoryEvent);
                 break;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -18,6 +18,7 @@ import {
     Logger,
     logger,
     LoggingDebugSession,
+    MemoryEvent,
     OutputEvent,
     Scope,
     Source,
@@ -3167,6 +3168,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             case 'cmd-param-changed':
                 this.handleCmdParamChanged(notifyData);
                 break;
+            case 'memory-changed':
+                const memoryEvent = new MemoryEvent(
+                    notifyData.addr,
+                    0,
+                    parseInt(notifyData.len)
+                );
+                this.sendEvent(memoryEvent);
+                    break;
             default:
                 logger.warn(
                     `GDB unhandled notify: ${notifyClass}: ${JSON.stringify(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3169,9 +3169,13 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.handleCmdParamChanged(notifyData);
                 break;
             case 'memory-changed': {
-                const length = isNaN(notifyData.len)
-                    ? 0
-                    : parseInt(notifyData.len, 10);
+                let length = 0;
+                if (isNaN(notifyData.len)) {
+                    logger.warn(
+                        `GDB notify "memory-changed" has invalid length: ${notifyData.len}`
+                    );
+                }
+                length = parseInt(notifyData.len);
                 const memoryEvent = new MemoryEvent(notifyData.addr, 0, length);
                 this.sendEvent(memoryEvent);
                 break;

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -199,6 +199,27 @@ describe('Memory Test Suite', function () {
         verifyReadMemoryResponse(memory, newValue, addrOfArray);
     });
 
+    it('can write memory and handle memory notifications from gdb', async function () {
+        const addrOfArray = parseInt(
+            (
+                await dc.evaluateRequest({
+                    expression: '&array[0]',
+                    frameId: frame.id,
+                })
+            ).body.result
+        );
+        const memoryEvent = dc.waitForEvent('memory');
+        await dc.evaluateRequest({
+            expression: '>set array[0] = 0xde',
+            frameId: frame.id,
+            context: 'repl',
+        });
+        //await dc.writeMemoryRequest(writeArguments);
+        const output = await memoryEvent;
+        expect(parseInt(output.body.memoryReference)).eq(addrOfArray);
+        expect(output.body.count).eq(1);
+    });
+
     it('fails when trying to write to read-only memory', async function () {
         const addrOfArray = parseInt(
             (

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -214,7 +214,6 @@ describe('Memory Test Suite', function () {
             frameId: frame.id,
             context: 'repl',
         });
-        //await dc.writeMemoryRequest(writeArguments);
         const output = await memoryEvent;
         expect(parseInt(output.body.memoryReference)).eq(addrOfArray);
         expect(output.body.count).eq(1);


### PR DESCRIPTION
Should solve https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/526

Handling GDB memory notifications by sending a DAP memory event.