### PR TITLE
Custom event for radix notify

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -23,6 +23,7 @@ import {
     Source,
     StackFrame,
     TerminatedEvent,
+    Event,
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { ContinuedEvent } from '../events/continuedEvent';
@@ -3015,6 +3016,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         switch (notifyData.param) {
             case 'output-radix':
                 this.sendEvent(new InvalidatedEvent(['variables']));
+                this.sendEvent(
+                    new Event('OutputRadixUpdated', {
+                        radix: notifyData.value,
+                    })
+                );
                 break;
             default:
                 break;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3015,12 +3015,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     private handleCmdParamChanged(notifyData: CmdParamChangedNotifyData) {
         switch (notifyData.param) {
             case 'output-radix':
-                this.sendEvent(new InvalidatedEvent(['variables']));
                 this.sendEvent(
                     new Event('OutputRadixUpdated', {
                         radix: notifyData.value,
                     })
                 );
+                this.sendEvent(new InvalidatedEvent(['variables']));
                 break;
             default:
                 break;

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -19,6 +19,7 @@ import {
     Scope,
     standardBeforeEach,
     testProgramsDir,
+    gdbAsync,
 } from './utils';
 import { expect } from 'chai';
 

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -196,18 +196,21 @@ describe('evaluate request', function () {
         expect(err.message).eq('Undefined MI command: a');
     });
 
-    it('should send invalidate event when changing global radix through evaluate request', async function () {
+    it('should send a custom event and an invalidate event when changing global radix through evaluate request', async function () {
         if (!(isRemoteTest && gdbAsync)) {
             this.skip();
         }
         const event = dc.waitForEvent('invalidated');
+        const customEvent = dc.waitForEvent('OutputRadixUpdated');
         await dc.evaluateRequest({
             context: 'repl',
             expression: '> set output-radix 16',
             frameId: scope.frame.id,
         });
         const invalidatedEvent = await event;
+        const outputRadixUpdatedEvent = await customEvent;
         expect(invalidatedEvent).to.be.not.undefined;
+        expect(outputRadixUpdatedEvent.body.radix).eq('16');
     });
 });
 

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -19,7 +19,6 @@ import {
     Scope,
     standardBeforeEach,
     testProgramsDir,
-    gdbAsync,
 } from './utils';
 import { expect } from 'chai';
 
@@ -301,9 +300,6 @@ describe('evaluate request', function () {
     });
 
     it('should send a custom event and an invalidate event when changing global radix through evaluate request', async function () {
-        if (!(isRemoteTest && gdbAsync)) {
-            this.skip();
-        }
         const event = dc.waitForEvent('invalidated');
         const customEvent = dc.waitForEvent('OutputRadixUpdated');
         await dc.evaluateRequest({

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -300,7 +300,7 @@ describe('evaluate request', function () {
         expect(monitorVariable?.value).to.equal('10');
     });
 
-     it('should send a custom event and an invalidate event when changing global radix through evaluate request', async function () {
+    it('should send a custom event and an invalidate event when changing global radix through evaluate request', async function () {
         if (!(isRemoteTest && gdbAsync)) {
             this.skip();
         }


### PR DESCRIPTION
Sending a custom event to notify clients of radix changes, with the radix provided in the payload

Related to https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/219