### PR TITLE
Add support set expression request

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2178,8 +2178,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     }
 
     // In implementing this request. We first try and check if the variable exists as is
-    protected async setExpressionRequest(response: DebugProtocol.SetExpressionResponse,
-                                         args: DebugProtocol.SetExpressionArguments): Promise<void> {
+    protected async setExpressionRequest(
+        response: DebugProtocol.SetExpressionResponse,
+        args: DebugProtocol.SetExpressionArguments
+    ): Promise<void> {
         if (!this.canRequestProceed()) {
             this.logger.verbose(
                 'Debug adapter cannot process set variable request, skipping it.'
@@ -2194,11 +2196,19 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 : undefined;
             const [gdb, frameRef, depth] =
                 await this.getFrameContext(initialFrameRef);
-            const varObj = this.gdb.varManager.getVar(frameRef, depth, args.expression);
+            const varObj = this.gdb.varManager.getVar(
+                frameRef,
+                depth,
+                args.expression
+            );
             if (!varObj) {
                 throw new Error(`Variable ${args.expression} not found`);
             } else {
-                const assign = await mi.sendVarAssign(gdb, {varname: varObj.varname, value: args.value, frameRef});
+                const assign = await mi.sendVarAssign(gdb, {
+                    varname: varObj.varname,
+                    value: args.value,
+                    frameRef,
+                });
                 response.body = {
                     value: assign.value,
                 };
@@ -2211,7 +2221,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 err instanceof Error ? err.message : String(err)
             );
         }
-        
     }
 
     /**

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1724,8 +1724,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 highFrame,
                 threadId,
             });
-            //const globalFrameHandle = this.frameHandles.create({threadId, frameId: 0}); // FrameId 0 is reserved for the global frame
-            //const globalFrame = new StackFrame(globalFrameHandle, 'Global Scope') as DebugProtocol.StackFrame;
+
             const stack = listResult.stack.map((frame) => {
                 let source;
                 if (frame.fullname) {
@@ -2109,14 +2108,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             if (varobj) {
                 assign = await mi.sendVarAssign(this.gdb, {
                     varname: varobj.varname,
-                    value: args.value,
+                    expression: args.value,
                     frameRef: frameRef,
                 });
             } else {
                 try {
                     assign = await mi.sendVarAssign(this.gdb, {
                         varname,
-                        value: args.value,
+                        expression: args.value,
                         frameRef: frameRef,
                     });
                 } catch (err) {
@@ -2141,7 +2140,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             try {
                                 assign = await mi.sendVarAssign(this.gdb, {
                                     varname: grandchildVarname,
-                                    value: args.value,
+                                    expression: args.value,
                                     frameRef: frameRef,
                                 });
                                 break;
@@ -2206,7 +2205,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             } else {
                 const assign = await mi.sendVarAssign(gdb, {
                     varname: varObj.varname,
-                    value: args.value,
+                    expression: args.value,
                     frameRef,
                 });
                 response.body = {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -420,7 +420,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.supportsHitConditionalBreakpoints = true;
         response.body.supportsLogPoints = true;
         response.body.supportsFunctionBreakpoints = true;
-        // response.body.supportsSetExpression = true;
+        response.body.supportsSetExpression = true;
         response.body.supportsDisassembleRequest = true;
         response.body.supportsReadMemoryRequest = true;
         response.body.supportsWriteMemoryRequest = true;
@@ -1724,7 +1724,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 highFrame,
                 threadId,
             });
-
+            //const globalFrameHandle = this.frameHandles.create({threadId, frameId: 0}); // FrameId 0 is reserved for the global frame
+            //const globalFrame = new StackFrame(globalFrameHandle, 'Global Scope') as DebugProtocol.StackFrame;
             const stack = listResult.stack.map((frame) => {
                 let source;
                 if (frame.fullname) {
@@ -2108,14 +2109,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             if (varobj) {
                 assign = await mi.sendVarAssign(this.gdb, {
                     varname: varobj.varname,
-                    expression: args.value,
+                    value: args.value,
                     frameRef: frameRef,
                 });
             } else {
                 try {
                     assign = await mi.sendVarAssign(this.gdb, {
                         varname,
-                        expression: args.value,
+                        value: args.value,
                         frameRef: frameRef,
                     });
                 } catch (err) {
@@ -2140,7 +2141,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             try {
                                 assign = await mi.sendVarAssign(this.gdb, {
                                     varname: grandchildVarname,
-                                    expression: args.value,
+                                    value: args.value,
                                     frameRef: frameRef,
                                 });
                                 break;
@@ -2176,11 +2177,42 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.sendResponse(response);
     }
 
-    // protected async setExpressionRequest(response: DebugProtocol.SetExpressionResponse,
-    //                                      args: DebugProtocol.SetExpressionArguments): Promise<void> {
-    //     logger.error('got setExpressionRequest');
-    //     this.sendResponse(response);
-    // }
+    // In implementing this request. We first try and check if the variable exists as is
+    protected async setExpressionRequest(response: DebugProtocol.SetExpressionResponse,
+                                         args: DebugProtocol.SetExpressionArguments): Promise<void> {
+        if (!this.canRequestProceed()) {
+            this.logger.verbose(
+                'Debug adapter cannot process set variable request, skipping it.'
+            );
+            console.log(args);
+            this.sendResponse(response);
+            return;
+        }
+        try {
+            const initialFrameRef = args.frameId
+                ? this.frameHandles.get(args.frameId)
+                : undefined;
+            const [gdb, frameRef, depth] =
+                await this.getFrameContext(initialFrameRef);
+            const varObj = this.gdb.varManager.getVar(frameRef, depth, args.expression);
+            if (!varObj) {
+                throw new Error(`Variable ${args.expression} not found`);
+            } else {
+                const assign = await mi.sendVarAssign(gdb, {varname: varObj.varname, value: args.value, frameRef});
+                response.body = {
+                    value: assign.value,
+                };
+            }
+            this.sendResponse(response);
+        } catch (err) {
+            this.sendErrorResponse(
+                response,
+                1,
+                err instanceof Error ? err.message : String(err)
+            );
+        }
+        
+    }
 
     /**
      * Send command to backend.

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2175,9 +2175,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             );
         }
         this.sendResponse(response);
+        this.sendEvent(new InvalidatedEvent(['variables']));
     }
 
-    // In implementing this request. We first try and check if the variable exists as is
     protected async setExpressionRequest(
         response: DebugProtocol.SetExpressionResponse,
         args: DebugProtocol.SetExpressionArguments
@@ -2214,6 +2214,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 };
             }
             this.sendResponse(response);
+            this.sendEvent(new InvalidatedEvent(['variables']));
         } catch (err) {
             this.sendErrorResponse(
                 response,

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2185,7 +2185,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             this.logger.verbose(
                 'Debug adapter cannot process set variable request, skipping it.'
             );
-            console.log(args);
             this.sendResponse(response);
             return;
         }
@@ -2200,6 +2199,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 depth,
                 args.expression
             );
+            // Not handling requests for expressions that do not have a dedicated GDB variable object for now.
             if (!varObj) {
                 throw new Error(`Variable ${args.expression} not found`);
             } else {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2195,7 +2195,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 : undefined;
             const [gdb, frameRef, depth] =
                 await this.getFrameContext(initialFrameRef);
-            const varObj = this.gdb.varManager.getVar(
+            const varObj = gdb.varManager.getVar(
                 frameRef,
                 depth,
                 args.expression

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -362,4 +362,44 @@ describe('evaluate request global variables', function () {
             });
         });
     });
+
+    it('should be able to set a global variable and have that change reflected in the debuggee', async function () {
+        // Read global variable using watch
+        const watchResParent = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 's1',
+            frameId: scope.frame.id,
+        });
+        const watchResChild = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 's1.m',
+            frameId: scope.frame.id,
+        });
+        expect(watchResParent.body.result).to.endWith('{...}');
+        expect(watchResChild.body.result).to.equal('10');
+
+        // Set global variable using setExpressionRequest
+        const setRes = await dc.customRequest('setExpression', {
+            expression: 's1.m',
+            value: '20',
+            frameId: scope.frame.id,
+        });
+        expect(setRes.body.value).to.equal('20');
+
+        // Read global variable again to check updated value is returned
+        const watchResChildUpdated = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 's1.m',
+            frameId: scope.frame.id,
+        });
+        expect(watchResChildUpdated.body.result).to.equal('20');
+
+        // Check updated value is reflected in the debuggee by evaluating an expression that uses the variable
+        const evalRes = await dc.evaluateRequest({
+            context: 'repl',
+            expression: 's1.m + 5',
+            frameId: scope.frame.id,
+        });
+        expect(evalRes.body.result).to.equal('25');
+    });
 });

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -363,7 +363,33 @@ describe('evaluate request global variables', function () {
         });
     });
 
-    it('should be able to set a global variable and have that change reflected in the debuggee', async function () {
+    it('should be able to set a simple global variable and have that change reflected in the debuggee', async function () {
+        // Read global_int using watch
+        const watchRes = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'global_int',
+            frameId: scope.frame.id,
+        });
+        expect(watchRes.body.result).to.equal('42');
+
+        // Set global_int using setExpressionRequest
+        const setRes = await dc.customRequest('setExpression', {
+            expression: 'global_int',
+            value: '100',
+            frameId: scope.frame.id,
+        });
+        expect(setRes.body.value).to.equal('100');
+
+        // Read global_int again to check updated value is returned
+        const watchResUpdated = await dc.evaluateRequest({
+            context: 'watch',
+            expression: 'global_int',
+            frameId: scope.frame.id,
+        });
+        expect(watchResUpdated.body.result).to.equal('100');
+    });
+
+    it('should be able to set a complex global variable and have that change reflected in the debuggee', async function () {
         // Read global variable using watch
         const watchResParent = await dc.evaluateRequest({
             context: 'watch',

--- a/src/integration-tests/test-programs/vars_globals.c
+++ b/src/integration-tests/test-programs/vars_globals.c
@@ -36,6 +36,8 @@ volatile PARENT_STRUCT s1 = {
 
 volatile PARENT_STRUCT *p_s1 = &s1;
 
+volatile int global_int = 42;
+
 int main()
 {
     // Struct with array

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -174,7 +174,7 @@ export function sendVarAssign(
     gdb: IGDBBackend,
     params: {
         varname: string;
-        expression: string;
+        value: string;
         frameRef?: FrameReference;
     }
 ): Promise<MIVarAssignResponse> {
@@ -185,7 +185,7 @@ export function sendVarAssign(
     if (params.frameRef?.frameId !== undefined) {
         command += ` --frame ${params.frameRef.frameId}`;
     }
-    command += ` ${params.varname} ${params.expression}`;
+    command += ` ${params.varname} ${params.value}`;
     return gdb.sendCommand(command);
 }
 

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -174,7 +174,7 @@ export function sendVarAssign(
     gdb: IGDBBackend,
     params: {
         varname: string;
-        value: string;
+        expression: string;
         frameRef?: FrameReference;
     }
 ): Promise<MIVarAssignResponse> {
@@ -185,7 +185,7 @@ export function sendVarAssign(
     if (params.frameRef?.frameId !== undefined) {
         command += ` --frame ${params.frameRef.frameId}`;
     }
-    command += ` ${params.varname} ${params.value}`;
+    command += ` ${params.varname} ${params.expression}`;
     return gdb.sendCommand(command);
 }
 


### PR DESCRIPTION
Supporting DAP setExpression request available [here](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExpression)


Users can then set values of expressions available in the `watch` window.