### PR TITLE
Add breakpoint locations request

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1581,7 +1581,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         return { resolved, deletes };
     }
 
-    protected async breakpointLocationsRequest(response: DebugProtocol.BreakpointLocationsResponse, args: DebugProtocol.BreakpointLocationsArguments): Promise<void> {
+    protected async breakpointLocationsRequest(
+        response: DebugProtocol.BreakpointLocationsResponse,
+        args: DebugProtocol.BreakpointLocationsArguments
+    ): Promise<void> {
         // Check if debug adapter is in a state to proceed with the request.
         if (!this.canRequestProceed()) {
             this.logger.verbose(
@@ -1597,13 +1600,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             const file = args.source.path;
             if (!file) {
                 throw new Error('Source path is missing');
-            }  
-            const availableLines = await mi.sendSymbolListLines(this.gdb, file); 
+            }
+            const availableLines = await mi.sendSymbolListLines(this.gdb, file);
             // Compare available lines with requested lines range and return the ones that are available in GDB
             const startLine = args.line;
             const endLine = args.endLine || args.line;
             const breakpoints = availableLines.lines
-                .filter((line) => parseInt(line.line, 10) >= startLine && parseInt(line.line, 10) <= endLine)
+                .filter(
+                    (line) =>
+                        parseInt(line.line, 10) >= startLine &&
+                        parseInt(line.line, 10) <= endLine
+                )
                 .map((line) => ({
                     line: parseInt(line.line, 10),
                 }));
@@ -1612,9 +1619,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             };
             this.sendResponse(response);
         } catch (err) {
-            if (err instanceof Error && err.message.includes('-symbol-list-lines: Unknown source file name.')) {
+            if (
+                err instanceof Error &&
+                err.message.includes(
+                    '-symbol-list-lines: Unknown source file name.'
+                )
+            ) {
                 // fail silently
-                this.logger.verbose(`GDB cannot provide breakpoint locations for file ${args.source.path}: ${err.message}`);
+                this.logger.verbose(
+                    `GDB cannot provide breakpoint locations for file ${args.source.path}: ${err.message}`
+                );
                 response.body = {
                     breakpoints: [],
                 };

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -429,6 +429,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response.body.supportsInstructionBreakpoints = true;
         response.body.supportsTerminateRequest = this.isRemote;
         response.body.supportsDataBreakpoints = true;
+        response.body.supportsBreakpointLocationsRequest = true;
         response.body.supportTerminateDebuggee = this.isRemote;
         response.body.breakpointModes = this.getBreakpointModes();
         this.sendResponse(response);
@@ -1578,6 +1579,49 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             .map((gdbbp) => gdbbp.number);
 
         return { resolved, deletes };
+    }
+
+    protected async breakpointLocationsRequest(response: DebugProtocol.BreakpointLocationsResponse, args: DebugProtocol.BreakpointLocationsArguments): Promise<void> {
+        // Check if debug adapter is in a state to proceed with the request.
+        if (!this.canRequestProceed()) {
+            this.logger.verbose(
+                'Debug adapter cannot process breakpoint locations request, skipping it.'
+            );
+            response.body = {
+                breakpoints: [],
+            };
+            this.sendResponse(response);
+            return;
+        }
+        try {
+            const file = args.source.path;
+            if (!file) {
+                throw new Error('Source path is missing');
+            }  
+            const availableLines = await mi.sendSymbolListLines(this.gdb, file); 
+            // Compare available lines with requested lines range and return the ones that are available in GDB
+            const startLine = args.line;
+            const endLine = args.endLine || args.line;
+            const breakpoints = availableLines.lines
+                .filter((line) => parseInt(line.line, 10) >= startLine && parseInt(line.line, 10) <= endLine)
+                .map((line) => ({
+                    line: parseInt(line.line, 10),
+                }));
+            response.body = {
+                breakpoints,
+            };
+            this.sendResponse(response);
+        } catch (err) {
+            if (err instanceof Error && err.message.includes('-symbol-list-lines: Unknown source file name.')) {
+                // fail silently
+                this.logger.verbose(`GDB cannot provide breakpoint locations for file ${args.source.path}: ${err.message}`);
+                response.body = {
+                    breakpoints: [],
+                };
+                this.sendResponse(response);
+                return;
+            }
+        }
     }
 
     protected async configurationDoneRequest(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1606,14 +1606,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             const startLine = args.line;
             const endLine = args.endLine || args.line;
             const breakpoints = availableLines.lines
-                .filter(
-                    (line) =>
-                        parseInt(line.line, 10) >= startLine &&
-                        parseInt(line.line, 10) <= endLine
-                )
                 .map((line) => ({
                     line: parseInt(line.line, 10),
-                }));
+                }))
+                .filter(
+                    (line) =>
+                        line.line >= startLine &&
+                        line.line <= endLine
+                );
             response.body = {
                 breakpoints,
             };

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1634,6 +1634,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 };
                 this.sendResponse(response);
                 return;
+            } else {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
             }
         }
     }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1610,9 +1610,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     line: parseInt(line.line, 10),
                 }))
                 .filter(
-                    (line) =>
-                        line.line >= startLine &&
-                        line.line <= endLine
+                    (line) => line.line >= startLine && line.line <= endLine
                 );
             response.body = {
                 breakpoints,

--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -885,4 +885,27 @@ describe('breakpoints', async function () {
         });
         expect(response.body.breakpoints.length).eq(0);
     });
+
+    it('uses breakpointLocations to verify valid breakpoint locations', async () => {
+        const response = await dc.customRequest('breakpointLocations', {
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            line: 1,
+            endLine: 10,
+        });
+        expect(response.body.breakpoints.length).to.be.greaterThan(0);
+        expect(response.body.breakpoints[0]).to.have.property('line');
+        // Line 6 should be a valid breakpoint location, as it has code
+        const line6 = response.body.breakpoints.find(
+            (bp: any) => bp.line === 6
+        );
+        expect(line6).not.eq(undefined);
+        // Line 5 should not be a valid breakpoint location, as it has no code
+        const line5 = response.body.breakpoints.find(
+            (bp: any) => bp.line === 5
+        );
+        expect(line5).eq(undefined);
+    });
 });

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 import { IGDBBackend } from '../types/gdb';
+import { standardEscape } from '../util/standardEscape';
 
 export interface MIDebugSymbol {
     line: string;
@@ -100,7 +101,7 @@ export async function sendSymbolListLines(
     file: string
 ): Promise<MISymbolListLinesResponse> {
     const response: MISymbolListLinesResponse = await gdb.sendCommand(
-        `-symbol-list-lines ${file}`
+        `-symbol-list-lines ${standardEscape(file)}`
     );
     return response;
 }

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -34,6 +34,13 @@ export interface MISymbolInfoResponse {
     };
 }
 
+export interface MISymbolListLinesResponse {
+    lines: {
+        pc: string;
+        line: string;
+    }[];
+}
+
 export function sendSymbolInfoVars(
     gdb: IGDBBackend,
     params?: {
@@ -87,3 +94,12 @@ export function sendSymbolInfoFunctions(
     }
     return gdb.sendCommand(command);
 }
+
+export async function sendSymbolListLines(
+    gdb: IGDBBackend,
+    file: string
+): Promise<MISymbolListLinesResponse> {
+    const response: MISymbolListLinesResponse = await gdb.sendCommand(`-symbol-list-lines ${file}`);
+    return response;
+}
+

--- a/src/mi/symbols.ts
+++ b/src/mi/symbols.ts
@@ -99,7 +99,8 @@ export async function sendSymbolListLines(
     gdb: IGDBBackend,
     file: string
 ): Promise<MISymbolListLinesResponse> {
-    const response: MISymbolListLinesResponse = await gdb.sendCommand(`-symbol-list-lines ${file}`);
+    const response: MISymbolListLinesResponse = await gdb.sendCommand(
+        `-symbol-list-lines ${file}`
+    );
     return response;
 }
-


### PR DESCRIPTION
Solves https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/538

I added support for `breakpointLocationsRequest`. Documentation available [here](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_BreakpointLocations).

I utilised the gdb/mi command -symbol-list-lines available [here](https://sourceware.org/gdb/current/onlinedocs/gdb.html/GDB_002fMI-Symbol-Query.html#GDB_002fMI-Symbol-Query)