### PR TITLE
Not showing error response as a notification pop-up when evaluate request context is repl

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2692,8 +2692,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.sendErrorResponse(response, {
                     id: 1, // Id = 1 has always been the case for evaluateRequests
                     format: err instanceof Error ? err.message : String(err),
-                    showUser: false,
-                    sendTelemetry: undefined,
+                    showUser: false
                 });
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2694,7 +2694,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     1,
                     err instanceof Error ? err.message : String(err),
                     undefined,
-                    2 // Send error only to telemtry to appear only in debug console and not in UI popups
+                    2 // Send error only to telemetry to appear only in debug console and not in UI popups
                 );
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2691,7 +2691,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             } else if (args.context === 'repl') {
                 this.sendErrorResponse(
                     response,
-                    1,
+                    1, // Id = 1 has always been the case for evaluateRequests
                     err instanceof Error ? err.message : String(err),
                     undefined,
                     2 // Send error only to telemetry to appear only in debug console and not in UI popups

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2692,7 +2692,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.sendErrorResponse(response, {
                     id: 1, // Id = 1 has always been the case for evaluateRequests
                     format: err instanceof Error ? err.message : String(err),
-                    showUser: false
+                    showUser: false,
                 });
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2688,11 +2688,19 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     response.success = false;
                 }
                 this.sendResponse(response);
+            } else if (args.context === 'repl') {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err),
+                    undefined,
+                    2 // Send error only to telemtry to appear only in debug console and not in UI popups
+                );
             } else {
                 this.sendErrorResponse(
                     response,
                     1,
-                    err instanceof Error ? err.message : String(err)
+                    err instanceof Error ? err.message : String(err),
                 );
             }
         }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2700,7 +2700,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.sendErrorResponse(
                     response,
                     1,
-                    err instanceof Error ? err.message : String(err),
+                    err instanceof Error ? err.message : String(err)
                 );
             }
         }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2689,13 +2689,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
                 this.sendResponse(response);
             } else if (args.context === 'repl') {
-                this.sendErrorResponse(
-                    response,
-                    1, // Id = 1 has always been the case for evaluateRequests
-                    err instanceof Error ? err.message : String(err),
-                    undefined,
-                    2 // Send error only to telemetry to appear only in debug console and not in UI popups
-                );
+                this.sendErrorResponse(response, {
+                    id: 1, // Id = 1 has always been the case for evaluateRequests
+                    format: err instanceof Error ? err.message : String(err),
+                    showUser: false,
+                });
             } else {
                 this.sendErrorResponse(
                     response,

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2693,7 +2693,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     id: 1, // Id = 1 has always been the case for evaluateRequests
                     format: err instanceof Error ? err.message : String(err),
                     showUser: false,
-                    sendTelemetry: undefined
+                    sendTelemetry: undefined,
                 });
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2693,6 +2693,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     id: 1, // Id = 1 has always been the case for evaluateRequests
                     format: err instanceof Error ? err.message : String(err),
                     showUser: false,
+                    sendTelemetry: undefined
                 });
             } else {
                 this.sendErrorResponse(


### PR DESCRIPTION
This should fix #545 

<img width="1053" height="74" alt="image" src="https://github.com/user-attachments/assets/d13d4724-dea2-4485-a4bc-1395516ff90f" />
