### PR TITLE
Optionally keep stopped threads stopped on attaching

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2502,7 +2502,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments
     ): Promise<void> {
-        return this.doEvaluateRequest(response, args, false);
+        return this.doEvaluateRequest(response, args, true);
     }
 
     private extractExpressionFormat(
@@ -2546,7 +2546,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async doEvaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments,
-        alwaysAllowCliCommand: boolean // if true, allows evaluation of expression without a frameId
+        alwaysAllowCliCommand: boolean // if true, allows evaluation of expression without a frameId (kept for compatibility)
     ): Promise<void> {
         response.body = {
             result: 'Error: could not evaluate expression',

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -212,7 +212,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     // keeps track of where in the configuration phase (between initialize event
     // and configurationDone response) we are
     protected configuringState: ConfiguringState = ConfiguringState.INITIAL;
-    protected isInitialized = false;
+    protected isInitialized = false; // unused here but kept for compatibility
     protected deferredStopEvents: any[] = [];
 
     /**
@@ -609,10 +609,6 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
         this.sendEvent(new InitializedEvent());
         this.isInitialized = true;
-        for (const resultData of this.deferredStopEvents) {
-            this.handleGDBStopped(resultData);
-        }
-        this.deferredStopEvents.splice(0);
     }
 
     protected async attachRequest(
@@ -778,12 +774,19 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.waitPaused = undefined;
     }
 
+    protected setConfiguringStateDone(): void {
+        this.configuringState = ConfiguringState.DONE;
+        for (const resultData of this.deferredStopEvents) {
+            this.handleGDBStopped(resultData);
+        }
+        this.deferredStopEvents.splice(0);
+    }
+
     protected async continueIfNeeded(): Promise<void> {
         if (this.pauseCount > 0) {
             this.pauseCount--;
             if (this.pauseCount === 0) {
                 if (this.configuringState === ConfiguringState.FINISHING) {
-                    this.configuringState = ConfiguringState.DONE;
                     if (
                         this.runAfterConfiguration == RequestArgRun.ALL ||
                         this.waitPausedNeeded
@@ -794,6 +797,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             await mi.sendExecRun(this.gdb);
                         }
                     }
+                    this.setConfiguringStateDone();
                 } else if (this.waitPausedNeeded) {
                     if (this.gdb.isNonStopMode()) {
                         await mi.sendExecContinue(
@@ -1731,7 +1735,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.configuringState = ConfiguringState.FINISHING;
                 await this.continueIfNeeded();
             } else {
-                this.configuringState = ConfiguringState.DONE;
+                this.setConfiguringStateDone();
             }
             this.sendResponse(response);
         } catch (err) {
@@ -3209,7 +3213,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     }
                 }
                 this.updateIsRunning();
-                if (this.isInitialized) {
+                if (this.configuringState == ConfiguringState.DONE) {
                     this.handleGDBResume(resultData);
                 } else {
                     // while we are deferring events, cancel previous stop events for the same thread
@@ -3288,7 +3292,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         newThreadsConfirmed ||
                         (wasRunning && !this.isRunning))
                 ) {
-                    if (this.isInitialized) {
+                    if (this.configuringState == ConfiguringState.DONE) {
                         this.handleGDBStopped(resultData);
                     } else {
                         this.deferredStopEvents.push(resultData);

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2385,15 +2385,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     /**
      * Send command to backend.
      * @param expression Command to be executed
+     * @returns Promise for: - MI response as JS object if MI command, - `undefined` if CLI command
      */
     protected async sendCommandToGdb(
         gdb: IGDBBackend,
         expression: string,
         frameRef: FrameReference | undefined
-    ): Promise<void> {
+    ): Promise<any> {
         if (expression.startsWith('-')) {
             // GDB/MI command
-            await gdb.sendCommand(expression);
+            return await gdb.sendCommand(expression);
         } else {
             // GDB CLI command
             await mi.sendInterpreterExecConsole(gdb, {
@@ -2444,9 +2445,13 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         frameRef: FrameReference | undefined
     ): Promise<void> {
         const trimmedExpression = expression.trim();
-        await this.sendCommandToGdb(this.gdb, trimmedExpression, frameRef);
+        const result = await this.sendCommandToGdb(
+            this.gdb,
+            trimmedExpression,
+            frameRef
+        );
         response.body = {
-            result: '\r',
+            result: result ? JSON.stringify(result) : '\r',
             variablesReference: 0,
         };
         await this.sendCommandToOtherGdbs(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -42,6 +42,7 @@ import {
     ObjectVariableReference,
     MemoryRequestArguments,
     CDTDisassembleArguments,
+    RequestArgRun,
 } from '../types/session';
 import { IGDBBackend, IGDBBackendFactory } from '../types/gdb';
 import { getInstructions } from '../util/disassembly';
@@ -177,6 +178,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
     protected updateThreadInfo: 'missing' | 'when-requested' | 'never' =
         'missing';
+    protected runAfterConfiguration: RequestArgRun = RequestArgRun.ALL;
 
     /**
      * State variables for pauseIfNeeded/continueIfNeeded logic, mostly used for
@@ -211,6 +213,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     // and configurationDone response) we are
     protected configuringState: ConfiguringState = ConfiguringState.INITIAL;
     protected isInitialized = false;
+    protected deferredStopEvents: any[] = [];
 
     /**
      *  customResetCommands from launch.json
@@ -350,6 +353,16 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     "Valid values are: 'missing', 'when-requested', or 'never'."
             );
         }
+        if (
+            args.run !== undefined &&
+            args.run !== RequestArgRun.ALL &&
+            args.run !== RequestArgRun.PRESERVE
+        ) {
+            throw new Error(
+                `Invalid value for 'run': '${args.run}'. ` +
+                    "Valid values are: 'all', 'preserve'."
+            );
+        }
     }
 
     /**
@@ -363,6 +376,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.steppingResponseTimeout =
             args.steppingResponseTimeout ?? DEFAULT_STEPPING_RESPONSE_TIMEOUT;
         this.updateThreadInfo = args.updateThreadInfo ?? 'missing';
+        this.runAfterConfiguration = args.run ?? RequestArgRun.ALL;
     }
 
     /**
@@ -595,6 +609,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
         this.sendEvent(new InitializedEvent());
         this.isInitialized = true;
+        for (const resultData of this.deferredStopEvents) {
+            this.handleGDBStopped(resultData);
+        }
+        this.deferredStopEvents.splice(0);
     }
 
     protected async attachRequest(
@@ -766,10 +784,15 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             if (this.pauseCount === 0) {
                 if (this.configuringState === ConfiguringState.FINISHING) {
                     this.configuringState = ConfiguringState.DONE;
-                    if (this.isAttach) {
-                        await mi.sendExecContinue(this.gdb);
-                    } else {
-                        await mi.sendExecRun(this.gdb);
+                    if (
+                        this.runAfterConfiguration == RequestArgRun.ALL ||
+                        this.waitPausedNeeded
+                    ) {
+                        if (this.isAttach) {
+                            await mi.sendExecContinue(this.gdb);
+                        } else {
+                            await mi.sendExecRun(this.gdb);
+                        }
                     }
                 } else if (this.waitPausedNeeded) {
                     if (this.gdb.isNonStopMode()) {
@@ -3188,6 +3211,20 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 this.updateIsRunning();
                 if (this.isInitialized) {
                     this.handleGDBResume(resultData);
+                } else {
+                    // while we are deferring events, cancel previous stop events for the same thread
+                    if (this.deferredStopEvents.length > 0) {
+                        if (resultData['thread-id'] === 'all') {
+                            this.deferredStopEvents.splice(0);
+                        } else if (resultData['thread-id'] !== undefined) {
+                            this.deferredStopEvents =
+                                this.deferredStopEvents.filter(
+                                    (stopResultData) =>
+                                        stopResultData['thread-id'] !==
+                                        resultData['thread-id']
+                                );
+                        }
+                    }
                 }
                 break;
             case 'stopped': {
@@ -3253,6 +3290,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 ) {
                     if (this.isInitialized) {
                         this.handleGDBStopped(resultData);
+                    } else {
+                        this.deferredStopEvents.push(resultData);
                     }
                 }
                 break;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -154,7 +154,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
      * (GDBTargetDebugSession) and never for type="gdb" (GDBDebugSession).
      */
     protected isRemote = false;
-    // isRunning === true means there are no threads stopped.
+    // isRunning === true means there are threads and none are stopped.
+    // When uncertain because we have not received the status of the newest
+    // threads yet, this is the last certain value.
     protected isRunning = false;
 
     protected supportsRunInTerminalRequest = false;
@@ -1725,7 +1727,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             name += ` (${thread.details})`;
         }
 
-        const running = thread.state === 'running';
+        // 'thread-created' notifications don't include a thread state, it comes
+        // later via a 'stopped' or 'running' notification.
+        const running =
+            thread.state === 'running'
+                ? true
+                : thread.state === 'stopped'
+                  ? false
+                  : undefined;
 
         return new ThreadWithStatus(parseInt(thread.id, 10), name, running);
     }
@@ -3148,15 +3157,19 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         return requestsToResolve.length > 0;
     }
 
+    private updateIsRunning() {
+        const newIsRunning = this.threads.some((t) => t.running === false) // have stopped
+            ? false
+            : this.threads.some((t) => t.running === undefined) // have unknown
+              ? undefined
+              : this.threads.some((t) => t.running === true); // have running
+        if (newIsRunning !== undefined) {
+            this.isRunning = newIsRunning;
+        }
+        // else leave this.isRunning at its previous known value
+    }
+
     protected handleGDBAsync(resultClass: string, resultData: any) {
-        const updateIsRunning = () => {
-            this.isRunning = this.threads.length ? true : false;
-            for (const thread of this.threads) {
-                if (!thread.running) {
-                    this.isRunning = false;
-                }
-            }
-        };
         switch (resultClass) {
             case 'running':
                 if (this.gdb.isNonStopMode()) {
@@ -3172,13 +3185,14 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         thread.running = true;
                     }
                 }
-                updateIsRunning();
+                this.updateIsRunning();
                 if (this.isInitialized) {
                     this.handleGDBResume(resultData);
                 }
                 break;
             case 'stopped': {
                 let suppressHandleGDBStopped = false;
+                let newThreadsConfirmed = false;
                 if (this.gdb.isNonStopMode()) {
                     const id = parseInt(resultData['thread-id'], 10);
                     for (const thread of this.threads) {
@@ -3202,6 +3216,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     }
                 } else {
                     for (const thread of this.threads) {
+                        if (thread.running === undefined) {
+                            newThreadsConfirmed = true;
+                        }
                         thread.running = false;
                         thread.lastRunToken = undefined;
                     }
@@ -3227,10 +3244,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
 
                 const wasRunning = this.isRunning;
-                updateIsRunning();
+                this.updateIsRunning();
                 if (
                     !suppressHandleGDBStopped &&
                     (this.gdb.isNonStopMode() ||
+                        newThreadsConfirmed ||
                         (wasRunning && !this.isRunning))
                 ) {
                     if (this.isInitialized) {
@@ -3267,6 +3285,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         switch (notifyClass) {
             case 'thread-created':
                 this.threads.push(this.convertThread(notifyData));
+                this.updateIsRunning();
                 this.missingThreadNames = true;
                 break;
             case 'thread-exited': {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -214,6 +214,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected configuringState: ConfiguringState = ConfiguringState.INITIAL;
     protected isInitialized = false; // unused here but kept for compatibility
     protected deferredStopEvents: any[] = [];
+    protected firstContinueIsRun = false;
 
     /**
      *  customResetCommands from launch.json
@@ -796,6 +797,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         } else {
                             await mi.sendExecRun(this.gdb);
                         }
+                    } else if (!this.isAttach) {
+                        // We would have sent a 'run' rather than a 'continue',
+                        // but since the user didn't want us to, let them do it
+                        // manually using a continue request.
+                        this.firstContinueIsRun = true;
                     }
                     this.setConfiguringStateDone();
                 } else if (this.waitPausedNeeded) {
@@ -2050,7 +2056,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         try {
-            await mi.sendExecContinue(this.gdb, args.threadId);
+            if (this.firstContinueIsRun) {
+                this.firstContinueIsRun = false;
+                await mi.sendExecRun(this.gdb);
+            } else {
+                await mi.sendExecContinue(this.gdb, args.threadId);
+            }
             let isAllThreadsContinued;
             if (this.gdb.isNonStopMode()) {
                 isAllThreadsContinued = args.threadId ? false : true;

--- a/src/gdb/common.ts
+++ b/src/gdb/common.ts
@@ -12,9 +12,9 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 export class ThreadWithStatus implements DebugProtocol.Thread {
     id: number;
     name: string;
-    running: boolean;
+    running?: boolean;
     lastRunToken: string | undefined;
-    constructor(id: number, name: string, running: boolean) {
+    constructor(id: number, name: string, running?: boolean) {
         this.id = id;
         this.name = name;
         this.running = running;

--- a/src/integration-tests/attach.spec.ts
+++ b/src/integration-tests/attach.spec.ts
@@ -17,6 +17,7 @@ import {
     fillDefaults,
     gdbAsync,
     gdbNonStop,
+    gdbVersionAtLeast,
     isRemoteTest,
     standardBeforeEach,
     testProgramsDir,
@@ -55,6 +56,73 @@ describe('attach', function () {
         await dc.attachHitBreakpoint(attachArgs, { line: 25, path: src });
         expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
     });
+
+    function makeRunArgTest(runArg: string) {
+        return async function (this: Mocha.Context) {
+            if (isRemoteTest) {
+                // attachRemote.spec.ts is the test for when isRemoteTest
+                this.skip();
+            }
+            const isAsync =
+                gdbAsync &&
+                (os.platform() !== 'win32' ||
+                    (await gdbVersionAtLeast('13.0')));
+            if (!isAsync && runArg === 'all') {
+                // in sync mode when all threads are running we can't ask '-thread-info'
+                this.skip();
+            }
+
+            const eventCounter = { stopped: 0, continued: 0 };
+            dc.on('stopped', () => {
+                eventCounter.stopped++;
+            });
+            dc.on('continued', () => {
+                eventCounter.continued++;
+            });
+
+            const attachArgs = fillDefaults(this.test, {
+                program: program,
+                processId: `${inferior.pid}`,
+                run: runArg,
+            } as AttachRequestArguments);
+
+            await Promise.all([
+                dc
+                    .waitForEvent('initialized')
+                    .then(() => dc.configurationDoneRequest()),
+                dc.initializeRequest().then(() => dc.attachRequest(attachArgs)),
+            ]);
+
+            const threadInfo = JSON.parse(
+                (
+                    await dc.evaluateRequest({
+                        expression: '>-thread-info',
+                        context: 'repl',
+                    })
+                ).body.result
+            );
+            const threadStates = threadInfo.threads.map((t: any) => t.state);
+            if (runArg === 'all') {
+                expect(threadStates).to.contain('running');
+                expect(threadStates).not.to.contain('stopped');
+            } else if (runArg === 'preserve') {
+                expect(threadStates).to.contain('stopped');
+            } else {
+                expect(runArg).to.be.oneOf(['all', 'preserve']);
+            }
+
+            expect(eventCounter).to.deep.equal({
+                stopped: runArg === 'all' ? 0 : 1,
+                continued: 0,
+            });
+        };
+    }
+
+    it('can attach and continue stopped threads', makeRunArgTest('all'));
+    it(
+        'can attach without continuing stopped threads',
+        makeRunArgTest('preserve')
+    );
 
     it('can attach and hit a breakpoint with no program specified', async function () {
         if (isRemoteTest) {

--- a/src/integration-tests/attach.spec.ts
+++ b/src/integration-tests/attach.spec.ts
@@ -115,6 +115,27 @@ describe('attach', function () {
                 stopped: runArg === 'all' ? 0 : 1,
                 continued: 0,
             });
+
+            // check that continue sends the right GDB commands
+            // (always -exec-continue for attach;
+            // first -exec-run, then -exec-continue for launch)
+            if (runArg === 'preserve') {
+                await dc.setBreakpointsRequest({
+                    source: { path: src },
+                    breakpoints: [{ line: 25 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 25 });
+                await dc.setBreakpointsRequest({
+                    source: { path: src },
+                    breakpoints: [{ line: 26 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 26 });
+
+                expect(eventCounter).to.deep.equal({
+                    stopped: 3,
+                    continued: 2,
+                });
+            }
         };
     }
 

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -23,6 +23,7 @@ import {
     gdbAsync,
     fillDefaults,
     gdbNonStop,
+    isRemoteTest,
 } from './utils';
 import { expect } from 'chai';
 import { DebugProtocol } from '@vscode/debugprotocol';
@@ -80,6 +81,72 @@ describe('attach remote', function () {
         await dc.attachHitBreakpoint(attachArgs, { line: 25, path: src });
         expect(await dc.evaluate('argv[1]')).to.contain('running-from-spawn');
     });
+
+    function makeRunArgTest(runArg: string) {
+        return async function (this: Mocha.Context) {
+            if (!isRemoteTest) {
+                // attach.spec.ts is the test for when !isRemoteTest
+                this.skip();
+            }
+            if ((!gdbAsync || !gdbNonStop) && runArg === 'all') {
+                // in sync mode when all threads are running we can't ask '-thread-info'
+                this.skip();
+            }
+
+            const eventCounter = { stopped: 0, continued: 0 };
+            dc.on('stopped', () => {
+                eventCounter.stopped++;
+            });
+            dc.on('continued', () => {
+                eventCounter.continued++;
+            });
+
+            const attachArgs = fillDefaults(this.test, {
+                program: program,
+                target: {
+                    type: 'remote',
+                    parameters: [`localhost:${port}`],
+                } as TargetAttachArguments,
+                run: runArg,
+            } as TargetAttachRequestArguments);
+
+            await Promise.all([
+                dc
+                    .waitForEvent('initialized')
+                    .then(() => dc.configurationDoneRequest()),
+                dc.initializeRequest().then(() => dc.attachRequest(attachArgs)),
+            ]);
+
+            const threadInfo = JSON.parse(
+                (
+                    await dc.evaluateRequest({
+                        expression: '>-thread-info',
+                        context: 'repl',
+                    })
+                ).body.result
+            );
+            const threadStates = threadInfo.threads.map((t: any) => t.state);
+            if (runArg === 'all') {
+                expect(threadStates).to.contain('running');
+                expect(threadStates).not.to.contain('stopped');
+            } else if (runArg === 'preserve') {
+                expect(threadStates).to.contain('stopped');
+            } else {
+                expect(runArg).to.be.oneOf(['all', 'preserve']);
+            }
+
+            expect(eventCounter).to.deep.equal({
+                stopped: runArg === 'all' ? 0 : 1,
+                continued: 0,
+            });
+        };
+    }
+
+    it('can attach and continue stopped threads', makeRunArgTest('all'));
+    it(
+        'can attach without continuing stopped threads',
+        makeRunArgTest('preserve')
+    );
 
     it('can attach remote and hit a breakpoint without a program', async function () {
         if (os.platform() === 'win32') {

--- a/src/integration-tests/attachRemote.spec.ts
+++ b/src/integration-tests/attachRemote.spec.ts
@@ -139,6 +139,27 @@ describe('attach remote', function () {
                 stopped: runArg === 'all' ? 0 : 1,
                 continued: 0,
             });
+
+            // check that continue sends the right GDB commands
+            // (always -exec-continue for attach;
+            // first -exec-run, then -exec-continue for launch)
+            if (runArg === 'preserve') {
+                await dc.setBreakpointsRequest({
+                    source: { path: src },
+                    breakpoints: [{ line: 25 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 25 });
+                await dc.setBreakpointsRequest({
+                    source: { path: src },
+                    breakpoints: [{ line: 26 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 26 });
+
+                expect(eventCounter).to.deep.equal({
+                    stopped: 3,
+                    continued: 2,
+                });
+            }
         };
     }
 

--- a/src/integration-tests/evaluate.spec.ts
+++ b/src/integration-tests/evaluate.spec.ts
@@ -180,7 +180,7 @@ describe('evaluate request', function () {
             frameId: scope.frame.id,
         });
 
-        expect(res2.body.result).eq('\r');
+        expect(res2.body.result).matches(/^\{.*\}$/);
     });
 
     it('should reject entering an invalid MI command', async function () {

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -36,6 +36,7 @@ describe('launch', function () {
     // the name of this file is short enough to work around https://sourceware.org/bugzilla/show_bug.cgi?id=30618
     const unicodeSrc = path.join(testProgramsDir, 'bug275-测试.c');
     const loopForeverProgram = path.join(testProgramsDir, 'loopforever');
+    const loopForeverSrc = path.join(testProgramsDir, 'loopforever.c');
 
     beforeEach(async function () {
         dc = await standardBeforeEach();
@@ -126,6 +127,27 @@ describe('launch', function () {
                 stopped: isRemoteTest ? (runArg === 'all' ? 0 : 1) : 0,
                 continued: 0,
             });
+
+            // check that continue sends the right GDB commands
+            // (always -exec-continue for attach;
+            // first -exec-run, then -exec-continue for launch)
+            if (runArg === 'preserve') {
+                await dc.setBreakpointsRequest({
+                    source: { path: loopForeverSrc },
+                    breakpoints: [{ line: 25 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 25 });
+                await dc.setBreakpointsRequest({
+                    source: { path: loopForeverSrc },
+                    breakpoints: [{ line: 26 }],
+                });
+                await dc.continue({ threadId: -1 }, 'breakpoint', { line: 26 });
+
+                expect(eventCounter).to.deep.equal({
+                    stopped: (isRemoteTest ? 1 : 0) + 2,
+                    continued: 2,
+                });
+            }
         };
     }
 

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -18,7 +18,9 @@ import {
 import { CdtDebugClient } from './debugClient';
 import {
     fillDefaults,
+    gdbAsync,
     gdbNonStop,
+    gdbVersionAtLeast,
     isRemoteTest,
     standardBeforeEach,
     testProgramsDir,
@@ -33,6 +35,7 @@ describe('launch', function () {
     const unicodeProgram = path.join(testProgramsDir, 'bug275-测试');
     // the name of this file is short enough to work around https://sourceware.org/bugzilla/show_bug.cgi?id=30618
     const unicodeSrc = path.join(testProgramsDir, 'bug275-测试.c');
+    const loopForeverProgram = path.join(testProgramsDir, 'loopforever');
 
     beforeEach(async function () {
         dc = await standardBeforeEach();
@@ -53,6 +56,81 @@ describe('launch', function () {
             }
         );
     });
+
+    function makeRunArgTest(runArg: string) {
+        return async function (this: Mocha.Context) {
+            // This tests both local and remote cases and does not need to be
+            // duplicated in launchRemote.spec.ts (beforeEach and afterEach are
+            // similar enough here and there).
+            const isAsync =
+                gdbAsync &&
+                (os.platform() !== 'win32' ||
+                    isRemoteTest ||
+                    (await gdbVersionAtLeast('13.0')));
+            if (
+                (!isAsync || (isRemoteTest && !gdbNonStop)) &&
+                runArg === 'all'
+            ) {
+                // in sync mode when all threads are running we can't ask '-thread-info'
+                // (remote needs non-stop to be really async)
+                this.skip();
+            }
+
+            const eventCounter = { stopped: 0, continued: 0 };
+            dc.on('stopped', () => {
+                eventCounter.stopped++;
+            });
+            dc.on('continued', () => {
+                eventCounter.continued++;
+            });
+
+            const launchArgs = fillDefaults(this.test, {
+                program: loopForeverProgram,
+                run: runArg,
+            } as LaunchRequestArguments);
+
+            await Promise.all([
+                dc
+                    .waitForEvent('initialized')
+                    .then(() => dc.configurationDoneRequest()),
+                dc.initializeRequest().then(() => dc.launchRequest(launchArgs)),
+            ]);
+
+            const threadInfo = JSON.parse(
+                (
+                    await dc.evaluateRequest({
+                        expression: '>-thread-info',
+                        context: 'repl',
+                    })
+                ).body.result
+            );
+            const threadStates = threadInfo.threads.map((t: any) => t.state);
+            if (runArg === 'all') {
+                expect(threadStates).to.contain('running');
+                expect(threadStates).not.to.contain('stopped');
+            } else if (runArg === 'preserve') {
+                if (isRemoteTest) {
+                    // GDBTargetDebugSession interprets "launch" as "launch
+                    // gdbserver", not "launch the program", so this case actually
+                    // behaves like an attach, not like a launch.
+                    expect(threadStates).to.contain('stopped');
+                } else {
+                    // GDBDebugSessionBase implements "launch" as expected.
+                    expect(threadStates).to.be.an('array').that.is.empty;
+                }
+            } else {
+                expect(runArg).to.be.oneOf(['all', 'preserve']);
+            }
+
+            expect(eventCounter).to.deep.equal({
+                stopped: isRemoteTest ? (runArg === 'all' ? 0 : 1) : 0,
+                continued: 0,
+            });
+        };
+    }
+
+    it('can launch and run', makeRunArgTest('all'));
+    it('can launch without running', makeRunArgTest('preserve'));
 
     it('receives an error when no port is provided nor a suitable regex', async function () {
         if (!isRemoteTest) {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -10,6 +10,11 @@
 import { Response } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 
+export const enum RequestArgRun {
+    ALL = 'all',
+    PRESERVE = 'preserve',
+}
+
 export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     gdb?: string;
     gdbArguments?: string[];
@@ -30,6 +35,7 @@ export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     customResetCommands?: string[];
     steppingResponseTimeout?: number;
     updateThreadInfo?: 'missing' | 'when-requested' | 'never';
+    run?: RequestArgRun;
 }
 
 export interface LaunchRequestArguments extends RequestArguments {


### PR DESCRIPTION
As discussed in #528:

Currently, when attaching to an inferior that already has some stopped threads, these threads are resumed by an indiscriminate _continue_ command in the final `continueIfNeeded` call at the end of the configuration phase. This is a problem for us: our systems can have breakpoints even when no debugger is attached, and when a thread stops on such a breakpoint, we want to be able to attach a debugger and analyze the thread in this stopped state, and not have it continued. It’s also inconsistent: continue*IfNeeded* is supposed to be a counterpart to pause*IfNeeded*, and pausing was not needed in this case because there was a paused thread already, so there shouldn’t be a matching _continue_ either.

### Commit 1

The first of the attached commits fixes that by inserting the appropriate `if (this.waitPausedNeeded)`. Because existing clients, and that in fact includes many of the tests, may expect the previous behavior, gate it behind an option in the launch/attach arguments: The new, optional property `"run"` can have values `"always"` or `"preserve"` (and potentially more in the future). `always` is the default and corresponds to the previous behavoir: always let all threads run. `preserve` is the new behavior: leave the running state of threads unchanged. Alternative suggestions for names of option and values are welcome.

This is not sufficient however to fully handle this situation: Because `async: stopped` notifications from GDB are not relayed to the client as DAP `stopped` events until `this.isInitialized`, which happens at the beginning of the configuration phase after the `initialized` event, and in this case the `stopped` notification from GDB comes earlier than that, the client would not know about the stopped thread and would display all threads as running. Even manually clicking _Pause_ on such a thread does not help, as that does not cause GDB to send another `stopped` notification because to it the thread is stopped already. Therefore, any `stopped` notifications from GDB that arrive during this time of suppression must not be simply discarded, but must be stored and delivered deferredly when the suppression ends. `running` notifications can still be discarded because running is the default state of a thread, but one that comes after a `stopped` notification for the same thread can cancel the latter. This is the rest of the first commit.

Moreover, in a situation that I am currently working on, this change is not just nice to have, but things would not work at all without it. The situation is that the stub is not attached to an inferior yet at the time GDB connects to it, but I only issue a `-target-attach 1 &` command just before the end of the configuration phase, after receiving breakpoints. This is possible when using the `extended-remote` target in GDB. (I can go into details separately on _why_ I am doing this, if anyone is interested.) In this case, there are no threads yet at the beginning of the configuration phase, so pausing is not needed, but they arrive before the end of the configuration phase and may all be running at that time. An indiscriminate _continue_ in that case results in an error “Cannot execute this command while the selected thread is running.” from GDB that takes down the whole debug session.

The first commit makes some tests in the _remote gdb-non-stop_ scenario fail with “AssertionError [ERR_ASSERTION]: '0' == 'breakpoint'”. That is not due to a problem with the code under test, but due to a problem with `DebugClient.hitBreakpoint()` from @vscode/debugadapter-testsupport. `hitBreakpoint` assumes that the very first `stopped` event comes from its breakpoint. That is not a reasonable assumption to make, and in fact is necessarily false in the situation that this commit seeks to enable, keeping stopped threads stopped. The only reason why it held so far is that we erroneously discarded early stop notifications before.

However, the problematic behavior of `hitBreakpoint` will be sidestepped as a side effect of the second commit, therefore I decided not to try to fix it here.

### Commit 2

The second commit is a further adaptation to this special situation of late attaching, but I think it does not hurt in the general case, so I am proposing it along with the first one: Unlike in the normal early-attach case (`remote` target), in the late-attach situation (`extended-remote` target), existing threads (a potentially large number of them) arrive from GDB via `async: running` notifications _after_ `this.isInitialized` is set, which therefore are no longer suppressed from going to the client as `continued` events. The client (at least VS Code) responds to each of them with a `threads` request, and if you have 110 threads as I do in my current example system, that results in a lot of completely unnecessary XML transmission over the remote connection and takes a long time. (I am guessing this is the reason why the suppression was introduced in the first place.) I therefore propose to defer continued/stopped events not just to the beginning, but to the _end_ of the configuration phase. This is what the second commit does. Does everyone agree that this does not cause any problems? The suppression could be extended even further without any harm, it does not cause us to miss anything except that the client only notices stopped/stopping threads once it is lifted, so there is no need to lift it until the user is ready for that.

This leaves the `isInitialized` variable unused, but since it is `protected` and may already be used by third-party subclasses, I am leaving it in.

As a side effect, because the longer suppression lets the `continued` event caused by the _continue_ command from `"run": "always"` cancel the deferred early `stopped` event that would confuse `hitBreakpoint`, this also avoids the test failures from the first commit. From here on, all tests should pass after every commit.

### Commit 3

A `launch` request with `"run": "preserve"` leaves GDB in the state where it has not started the program yet. To start the program, GDB needs a _run_ command. So far, there has been no way for the user to explicitly send that command through DAP, other than typing it in the debug console, it was only sent automatically in the `"run": "always"` (default) case. Therefore, in the `preserve` case, let the first DAP `continue` request send _run_ instead of _continue_ to GDB (the latter would not be accepted in this state anyway).

### Commits 4–6

Since all the existing tests run without a `run` option and therefore in the `always` mode, add some tests for explicit `run` options and the `preserve` mode in commit 6. To check whether threads are in the desired running/stopped state, these tests send the `-thread-info` command to GDB, which is much simpler than piecing together this information from DAP responses and events. Making this possible required some further modifications in commits 4 and 5:

- Accept GDB commands without a frame ID also in `gdb`, not just `gdbtarget` debug type – see also #414 and https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/202#pullrequestreview-3860526810 (middle).
- Return the result from an evaluated MI command.

Closes #528.