### PR TITLE
Catch errors from pause

### DIFF
--- a/src/gdb/GDBBackend.ts
+++ b/src/gdb/GDBBackend.ts
@@ -295,9 +295,9 @@ export class GDBBackend extends events.EventEmitter implements IGDBBackend {
         return this.hardwareBreakpoint;
     }
 
-    public pause(threadId?: number) {
+    public pause(threadId?: number): Promise<void> | void {
         if (this.gdbAsync) {
-            sendExecInterrupt(this, threadId);
+            return sendExecInterrupt(this, threadId) as Promise<void>;
         } else {
             if (!this.proc) {
                 throw new Error('GDB is not running, nothing to interrupt');

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2046,7 +2046,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         }
 
         try {
-            this.gdb.pause(args.threadId);
+            // no need to await the result, but do catch any exceptions/rejections
+            await this.gdb.pause(args.threadId);
             this.sendResponse(response);
         } catch (err) {
             this.sendErrorResponse(


### PR DESCRIPTION
When trying to pause a thread, if the `-exec-interrupt` command failed for any reason, e.g. thread already terminated, we would end up with an unhandled exception that may kill the adapter (unless its `uncaughtException` handler, against recommendations, ignores the exception, which the one from src/debug[Target]Adapter.ts does, but third-party ones (such as mine) may not). Fix this by awaiting the returned promise even though this is a fire-and-forget request.

There is some mismatch between `Promise<void>` and `Promise<unknown>` that pops up as a compiler error when you do it the straightforward way, is there any more elegant way of pleasing the TypeScript compiler than the `as Promise<void>` I added? In my understanding, `unknown` (the supertype of everything) should be assignable to `void` (which means “don’t do anything with this” and therefore accepts anything, at least when used as the return type of a function type), but the compiler seems to disagree.

<details>
<summary><h4>Steps to Reproduce</h4></summary>

The problem is a bit tricky to reproduce because it relies on a race condition. I originally saw it in a messed up situation while experimenting, but here is a way I can reproduce it with an unmodified debug adapter. Maybe there are easier ways. The idea is to send the pause request at a time when GDB has already noticed that the thread has exited, but the DAP client has not yet.

1. Run the debug adapter in the debugger using the “Server” launch configuration.
2. In the client, add the following launch configuration:
    ```json
    {
        "type": "gdb",
        "request": "launch",
        "name": "MultiThread",
        "program": ".../cdt-gdb-adapter/src/integration-tests/test-programs/MultiThread",
        "debugServer": 4711,
        "verbose": true
    }
    ```
3. Set a breakpoint on https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/603f5e4793e474a6c4abcb57c789a1554b8fe97d/src/integration-tests/test-programs/MultiThread.cc#L114, launch, and wait for the breakpoint to be hit after 30 seconds. You should see 6 threads in the Call Stack view.
4. In the debug adapter, set a breakpoint on https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/603f5e4793e474a6c4abcb57c789a1554b8fe97d/src/gdb/GDBDebugSessionBase.ts#L1783 in in `threadsRequest()`.
5. In the MultiThread program, Step Over. This causes the breakpoint in the adapter to be hit.
6. While the adapter is stopped on the breakpoint, click the Pause buttons on the “monday” through “thursday” threads. Nothing happens.
7. Continue the adapter.

**Actual Result:** Output `{"backend":"","name":"GDBError"}` from the adapter. You can also set a breakpoint on https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/603f5e4793e474a6c4abcb57c789a1554b8fe97d/src/debugAdapter.ts#L16 in the uncaughtException handler to verify that it comes from there.

**Expected Result:** A bunch of “Invalid thread id:” error notifications in the client. No uncaught exceptions in the adapter.
</details>