### PR TITLE
Make capabilities extensible by subclasses

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -427,25 +427,29 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         this.supportsGdbConsole =
             os.platform() === 'linux' && this.supportsRunInTerminalRequest;
         response.body = response.body || {};
-        response.body.supportsConfigurationDoneRequest = true;
-        response.body.supportsEvaluateForHovers = true;
-        response.body.supportsSetVariable = true;
-        response.body.supportsConditionalBreakpoints = true;
-        response.body.supportsHitConditionalBreakpoints = true;
-        response.body.supportsLogPoints = true;
-        response.body.supportsFunctionBreakpoints = true;
-        response.body.supportsSetExpression = true;
-        response.body.supportsDisassembleRequest = true;
-        response.body.supportsReadMemoryRequest = true;
-        response.body.supportsWriteMemoryRequest = true;
-        response.body.supportsSteppingGranularity = true;
-        response.body.supportsInstructionBreakpoints = true;
-        response.body.supportsTerminateRequest = this.isRemote;
-        response.body.supportsDataBreakpoints = true;
-        response.body.supportsBreakpointLocationsRequest = true;
-        response.body.supportTerminateDebuggee = this.isRemote;
-        response.body.breakpointModes = this.getBreakpointModes();
+        this.getCapabilities(response.body);
         this.sendResponse(response);
+    }
+
+    protected getCapabilities(cap: DebugProtocol.Capabilities): void {
+        cap.supportsConfigurationDoneRequest = true;
+        cap.supportsEvaluateForHovers = true;
+        cap.supportsSetVariable = true;
+        cap.supportsConditionalBreakpoints = true;
+        cap.supportsHitConditionalBreakpoints = true;
+        cap.supportsLogPoints = true;
+        cap.supportsFunctionBreakpoints = true;
+        cap.supportsSetExpression = true;
+        cap.supportsDisassembleRequest = true;
+        cap.supportsReadMemoryRequest = true;
+        cap.supportsWriteMemoryRequest = true;
+        cap.supportsSteppingGranularity = true;
+        cap.supportsInstructionBreakpoints = true;
+        cap.supportsTerminateRequest = this.isRemote;
+        cap.supportsDataBreakpoints = true;
+        cap.supportsBreakpointLocationsRequest = true;
+        cap.supportTerminateDebuggee = this.isRemote;
+        cap.breakpointModes = this.getBreakpointModes();
     }
 
     private switchOutputToError(input: string, category: string): StreamOutput {


### PR DESCRIPTION
Third-party debug session subclasses may want to advertise different capabilities to clients in the `initialize` handshake than GDBDebugSessionBase. However, doing that by overriding `initializeRequest()` is inconvenient, because such an override cannot call the superclass to retrieve its capabilities and then modify them before sending them to the client, because the superclass method already sends its own result to the client. Therefore factor out the filling-in of capabilities into a side-effect-free method that can be more conveniently overridden and super-called.

I was not sure whether the new `getCapabilities` method should _return_ the capabilities as a new object or fill them into an existing object, and chose the latter just because that matches the previous code more closely. I cannot think of much compelling reason for or against either, the ease of overriding is about the same – any opinions?

(The reason I want this is that I want to turn off `supportsTerminateRequest` and `supportTerminateDebuggee`, because my debuggee is an embedded system that cannot terminate, and I am currently working on a `launch` debug configuration, for which VS Code would otherwise put “terminate” on the prominent button in the debug toolbar and “disconnect”, which I want, only on its secondary function. That wouldn’t currently actually be much of a problem, because currently “terminate” eventually also results in a disconnection, but as I argue in https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/522#issuecomment-4236866156, I think that is wrong.)
