### PR TITLE
GDB server needs timeout to exit gracefully when disconnect

### DIFF
--- a/src/desktop/GDBTargetDebugSession.ts
+++ b/src/desktop/GDBTargetDebugSession.ts
@@ -915,7 +915,7 @@ export class GDBTargetDebugSession extends GDBDebugSession {
         args: DebugProtocol.DisconnectArguments
     ): Promise<void> {
         try {
-            await this.doDisconnectRequest(0, args?.terminateDebuggee);
+            await this.doDisconnectRequest(this.serverDisconnectTimeout, args?.terminateDebuggee);
             if (this.sessionInfo.disconnectError) {
                 this.sendErrorResponse(
                     response,


### PR DESCRIPTION
When disconnecting, the GDB server may be terminated before it finishes cleanup. Add a timeout to allow it to exit gracefully.