### PR TITLE
Fix variables view for anonymous unions/structs

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3638,9 +3638,20 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             });
         }
         // Grab the full path of parent.
-        const topLevelPathExpression =
-            varobj?.expression ??
-            (await this.getFullPathExpression(parentVarname, gdb));
+        let topLevelPathExpression = varobj?.expression;
+        // When -var-info-path-expression returns '', it's probably an anonymous
+        // struct or union - strip trailing .-separated components from the
+        // varobj name until we reach a non-anonymous ancestor
+        while (!topLevelPathExpression && parentVarname) {
+            topLevelPathExpression = await this.getFullPathExpression(
+                parentVarname,
+                gdb
+            );
+            parentVarname = parentVarname.substring(
+                0,
+                parentVarname.lastIndexOf('.')
+            );
+        }
 
         // iterate through the children
         for (const child of children.children) {

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3647,7 +3647,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             // check if we're dealing with a C++ object. If we are, we need to fetch the grandchildren instead.
             const isClass = this.isChildOfClass(child);
             if (isClass) {
-                const name = `${parentVarname}.${child.exp}`;
+                const name = child.name;
                 const objChildren = await mi.sendVarListChildren(gdb, {
                     name,
                     printValues: mi.MIVarPrintValues.all,
@@ -3655,7 +3655,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 // Append the child path to the top level full path.
                 const parentClassName = `${topLevelPathExpression}.${child.exp}`;
                 for (const objChild of objChildren.children) {
-                    const childName = `${name}.${objChild.exp}`;
+                    const childName = objChild.name;
                     variables.push({
                         name: objChild.exp,
                         evaluateName: `${parentClassName}.${objChild.exp}`,
@@ -3673,7 +3673,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
             } else {
                 // check if we're dealing with an array
-                let name = `${ref.varobjName}.${child.exp}`;
+                let name = child.name;
                 const varobjName = name;
                 const value = child.value ? child.value : child.type;
                 const isArrayChild =

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3652,13 +3652,12 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     name,
                     printValues: mi.MIVarPrintValues.all,
                 });
-                // Append the child path to the top level full path.
-                const parentClassName = `${topLevelPathExpression}.${child.exp}`;
                 for (const objChild of objChildren.children) {
                     const childName = objChild.name;
                     variables.push({
                         name: objChild.exp,
-                        evaluateName: `${parentClassName}.${objChild.exp}`,
+                        // Append the grandchild path to the top level full path, without intervening 'public' etc. (child.exp)
+                        evaluateName: `${topLevelPathExpression}.${objChild.exp}`,
                         value: objChild.value ? objChild.value : objChild.type,
                         type: objChild.type,
                         variablesReference:

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3668,7 +3668,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     variables.push({
                         name: objChild.exp,
                         // Append the grandchild path to the top level full path, without intervening 'public' etc. (child.exp)
-                        evaluateName: `${topLevelPathExpression}.${objChild.exp}`,
+                        evaluateName: objChild.exp.startsWith('<anonymous ')
+                            ? topLevelPathExpression
+                            : `${topLevelPathExpression}.${objChild.exp}`,
                         value: objChild.value ? objChild.value : objChild.type,
                         type: objChild.type,
                         variablesReference:
@@ -3696,7 +3698,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 const variableName = isArrayChild ? name : child.exp;
                 const evaluateName = isArrayChild
                     ? `${topLevelPathExpression}[${child.exp}]`
-                    : `${topLevelPathExpression}.${child.exp}`;
+                    : child.exp.startsWith('<anonymous ')
+                      ? topLevelPathExpression
+                      : `${topLevelPathExpression}.${child.exp}`;
                 variables.push({
                     name: variableName,
                     evaluateName,

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3658,13 +3658,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             // check if we're dealing with a C++ object. If we are, we need to fetch the grandchildren instead.
             const isClass = this.isChildOfClass(child);
             if (isClass) {
-                const name = child.name;
                 const objChildren = await mi.sendVarListChildren(gdb, {
-                    name,
+                    name: child.name,
                     printValues: mi.MIVarPrintValues.all,
                 });
                 for (const objChild of objChildren.children) {
-                    const childName = objChild.name;
                     variables.push({
                         name: objChild.exp,
                         // Append the grandchild path to the top level full path, without intervening 'public' etc. (child.exp)
@@ -3678,24 +3676,21 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                                 ? this.variableHandles.create({
                                       type: 'object',
                                       frameHandle: ref.frameHandle,
-                                      varobjName: childName,
+                                      varobjName: objChild.name,
                                   })
                                 : 0,
                     });
                 }
             } else {
                 // check if we're dealing with an array
-                let name = child.name;
-                const varobjName = name;
                 const value = child.value ? child.value : child.type;
                 const isArrayChild =
                     arrayChildRegex.test(child.exp) &&
                     (!varobj || arrayRegex.test(varobj.type));
-                if (isArrayChild) {
-                    // update the display name for array elements to have square brackets
-                    name = `[${child.exp}]`;
-                }
-                const variableName = isArrayChild ? name : child.exp;
+                // update the display name for array elements to have square brackets
+                const variableName = isArrayChild
+                    ? `[${child.exp}]`
+                    : child.exp;
                 const evaluateName = isArrayChild
                     ? `${topLevelPathExpression}[${child.exp}]`
                     : child.exp.startsWith('<anonymous ')
@@ -3711,7 +3706,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                             ? this.variableHandles.create({
                                   type: 'object',
                                   frameHandle: ref.frameHandle,
-                                  varobjName,
+                                  varobjName: child.name,
                               })
                             : 0,
                 });

--- a/src/integration-tests/test-programs/vars.c
+++ b/src/integration-tests/test-programs/vars.c
@@ -19,6 +19,32 @@ struct foo
     struct baz aa;
 };
 
+struct nest {
+    int one;
+    union {
+        int two;
+        unsigned int three;
+    };
+    union {
+        int four;
+        unsigned int five;
+        struct {
+            int a;
+            union {
+                struct {
+                    int b;
+                    int c;
+                };
+                struct {
+                    int d;
+                    int e;
+                };
+            };
+        } more[3];
+        int matrix[3][2];
+    };
+};
+
 int main()
 {
     int a = 1;
@@ -32,5 +58,6 @@ int main()
     int rax = 1;
     const unsigned char h[] = {0x01, 0x10, 0x20};
     const unsigned char k[] = "hello"; // char string setup
-    return 0;
+    struct nest n = {0};
+    return 0; // end
 }

--- a/src/integration-tests/test-programs/vars_cpp.cpp
+++ b/src/integration-tests/test-programs/vars_cpp.cpp
@@ -29,11 +29,38 @@ Foo::Foo(int a, int b, char c)
     this->c = c;
 }
 
+struct Nest {
+    int one;
+    union {
+        int two;
+        unsigned int three;
+    };
+    union {
+        int four;
+        unsigned int five;
+        struct {
+            int a;
+            union {
+                struct {
+                    int b;
+                    int c;
+                };
+                struct {
+                    int d;
+                    int e;
+                };
+            };
+        } more[3];
+        int matrix[3][2];
+    };
+};
+
 int main()
 {
     Foo *fooA = new Foo(1, 2, 'a');
     Foo *fooB = new Foo(3, 4, 'b');
     Foo *fooarr[] = {fooA, fooB};
+    Nest n = {0};
     cout << "!!!Hello World!!!" << endl; // STOP HERE
     cout << "!!!Hello World Again!!!" << endl;
     return 0;

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -23,7 +23,7 @@ import {
     fillDefaults,
 } from './utils';
 
-describe.only('Variables Test Suite', function () {
+describe('Variables Test Suite', function () {
     let dc: CdtDebugClient;
     let scope: Scope;
     const varsProgram = path.join(testProgramsDir, 'vars');

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -9,6 +9,7 @@
  *********************************************************************/
 
 import { expect } from 'chai';
+import * as fs from 'fs';
 import * as path from 'path';
 import { CdtDebugClient } from './debugClient';
 import {
@@ -22,17 +23,18 @@ import {
     fillDefaults,
 } from './utils';
 
-describe('Variables Test Suite', function () {
+describe.only('Variables Test Suite', function () {
     let dc: CdtDebugClient;
     let scope: Scope;
     const varsProgram = path.join(testProgramsDir, 'vars');
     const varsSrc = path.join(testProgramsDir, 'vars.c');
-    const numVars = 11; // number of variables in the main() scope of vars.c
+    const numVars = 12; // number of variables in the main() scope of vars.c
 
     const lineTags = {
         'STOP HERE': 0,
         'After array init': 0,
         'char string setup': 0,
+        end: 0,
     };
 
     const hexValueRegex = /^0x[\da-fA-F]+$/;
@@ -550,6 +552,71 @@ describe('Variables Test Suite', function () {
         });
         expect(res.body.result).eq(
             '[\n  "104 \'h\'",\n  "101 \'e\'",\n  "108 \'l\'",\n  "108 \'l\'",\n  "111 \'o\'",\n  "0 \'\\\\000\'"\n]'
+        );
+    });
+
+    it('can evaluate anonymous and deeply nested structs and unions', async function () {
+        // skip ahead to the end
+        const br = await dc.setBreakpointsRequest({
+            source: { path: varsSrc },
+            breakpoints: [{ line: lineTags['end'] }],
+        });
+        expect(br.success).to.equal(true);
+        await dc.continue({ threadId: scope.thread.id }, 'breakpoint', {
+            line: lineTags['end'],
+            path: varsSrc,
+        });
+        scope = await getScopes(dc);
+        expect(
+            scope.scopes.body.scopes.length,
+            'Unexpected number of scopes returned'
+        ).to.equal(2);
+        // assert we can see the struct
+        const vr = scope.scopes.body.scopes[0].variablesReference;
+        const vars = await dc.variablesRequest({ variablesReference: vr });
+        expect(
+            vars.body.variables.length,
+            'There is a different number of variables than expected'
+        ).to.equal(numVars);
+        verifyVariable(vars.body.variables[11], 'n', 'struct nest', '{...}', {
+            hasChildren: true,
+        });
+
+        interface ExpandedVariable {
+            name: string;
+            type?: string;
+            evaluateName?: string;
+            children?: ExpandedVariable[];
+        }
+        async function expandRecursively(
+            variablesReference: number
+        ): Promise<ExpandedVariable[] | undefined> {
+            if (variablesReference <= 0) return undefined;
+            const vars = (await dc.variablesRequest({ variablesReference }))
+                .body.variables;
+            const exp = await Promise.all(
+                vars.map((v) => expandRecursively(v.variablesReference))
+            );
+            return vars.map((v, i) => {
+                const r: ExpandedVariable = {
+                    name: v.name,
+                    type: v.type,
+                    evaluateName: v.evaluateName,
+                };
+                if (exp[i]) r.children = exp[i];
+                return r;
+            });
+        }
+        const structure = await expandRecursively(
+            vars.body.variables[11].variablesReference
+        );
+        expect(structure).to.deep.equal(
+            JSON.parse(
+                fs.readFileSync(
+                    path.join(testProgramsDir, '..', 'var_nest_expected.json'),
+                    { encoding: 'utf-8' }
+                )
+            )
         );
     });
 });

--- a/src/integration-tests/var_nest_expected.json
+++ b/src/integration-tests/var_nest_expected.json
@@ -1,0 +1,265 @@
+[
+  {
+    "name": "one",
+    "type": "int",
+    "evaluateName": "n.one"
+  },
+  {
+    "name": "<anonymous union>",
+    "type": "union {...}",
+    "evaluateName": "n",
+    "children": [
+      {
+        "name": "two",
+        "type": "int",
+        "evaluateName": "n.two"
+      },
+      {
+        "name": "three",
+        "type": "unsigned int",
+        "evaluateName": "n.three"
+      }
+    ]
+  },
+  {
+    "name": "<anonymous union>",
+    "type": "union {...}",
+    "evaluateName": "n",
+    "children": [
+      {
+        "name": "four",
+        "type": "int",
+        "evaluateName": "n.four"
+      },
+      {
+        "name": "five",
+        "type": "unsigned int",
+        "evaluateName": "n.five"
+      },
+      {
+        "name": "more",
+        "type": "struct {...} [3]",
+        "evaluateName": "n.more",
+        "children": [
+          {
+            "name": "[0]",
+            "type": "struct {...}",
+            "evaluateName": "n.more[0]",
+            "children": [
+              {
+                "name": "a",
+                "type": "int",
+                "evaluateName": "n.more[0].a"
+              },
+              {
+                "name": "<anonymous union>",
+                "type": "union {...}",
+                "evaluateName": "n.more[0]",
+                "children": [
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[0]",
+                    "children": [
+                      {
+                        "name": "b",
+                        "type": "int",
+                        "evaluateName": "n.more[0].b"
+                      },
+                      {
+                        "name": "c",
+                        "type": "int",
+                        "evaluateName": "n.more[0].c"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[0]",
+                    "children": [
+                      {
+                        "name": "d",
+                        "type": "int",
+                        "evaluateName": "n.more[0].d"
+                      },
+                      {
+                        "name": "e",
+                        "type": "int",
+                        "evaluateName": "n.more[0].e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "[1]",
+            "type": "struct {...}",
+            "evaluateName": "n.more[1]",
+            "children": [
+              {
+                "name": "a",
+                "type": "int",
+                "evaluateName": "n.more[1].a"
+              },
+              {
+                "name": "<anonymous union>",
+                "type": "union {...}",
+                "evaluateName": "n.more[1]",
+                "children": [
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[1]",
+                    "children": [
+                      {
+                        "name": "b",
+                        "type": "int",
+                        "evaluateName": "n.more[1].b"
+                      },
+                      {
+                        "name": "c",
+                        "type": "int",
+                        "evaluateName": "n.more[1].c"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[1]",
+                    "children": [
+                      {
+                        "name": "d",
+                        "type": "int",
+                        "evaluateName": "n.more[1].d"
+                      },
+                      {
+                        "name": "e",
+                        "type": "int",
+                        "evaluateName": "n.more[1].e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "[2]",
+            "type": "struct {...}",
+            "evaluateName": "n.more[2]",
+            "children": [
+              {
+                "name": "a",
+                "type": "int",
+                "evaluateName": "n.more[2].a"
+              },
+              {
+                "name": "<anonymous union>",
+                "type": "union {...}",
+                "evaluateName": "n.more[2]",
+                "children": [
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[2]",
+                    "children": [
+                      {
+                        "name": "b",
+                        "type": "int",
+                        "evaluateName": "n.more[2].b"
+                      },
+                      {
+                        "name": "c",
+                        "type": "int",
+                        "evaluateName": "n.more[2].c"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "<anonymous struct>",
+                    "type": "struct {...}",
+                    "evaluateName": "n.more[2]",
+                    "children": [
+                      {
+                        "name": "d",
+                        "type": "int",
+                        "evaluateName": "n.more[2].d"
+                      },
+                      {
+                        "name": "e",
+                        "type": "int",
+                        "evaluateName": "n.more[2].e"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "matrix",
+        "type": "int [3][2]",
+        "evaluateName": "n.matrix",
+        "children": [
+          {
+            "name": "[0]",
+            "type": "int [2]",
+            "evaluateName": "n.matrix[0]",
+            "children": [
+              {
+                "name": "[0]",
+                "type": "int",
+                "evaluateName": "n.matrix[0][0]"
+              },
+              {
+                "name": "[1]",
+                "type": "int",
+                "evaluateName": "n.matrix[0][1]"
+              }
+            ]
+          },
+          {
+            "name": "[1]",
+            "type": "int [2]",
+            "evaluateName": "n.matrix[1]",
+            "children": [
+              {
+                "name": "[0]",
+                "type": "int",
+                "evaluateName": "n.matrix[1][0]"
+              },
+              {
+                "name": "[1]",
+                "type": "int",
+                "evaluateName": "n.matrix[1][1]"
+              }
+            ]
+          },
+          {
+            "name": "[2]",
+            "type": "int [2]",
+            "evaluateName": "n.matrix[2]",
+            "children": [
+              {
+                "name": "[0]",
+                "type": "int",
+                "evaluateName": "n.matrix[2][0]"
+              },
+              {
+                "name": "[1]",
+                "type": "int",
+                "evaluateName": "n.matrix[2][1]"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -23,7 +23,7 @@ import {
     fillDefaults,
 } from './utils';
 
-describe.only('Variables CPP Test Suite', function () {
+describe('Variables CPP Test Suite', function () {
     let dc: CdtDebugClient;
     let scope: Scope;
 

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -9,6 +9,7 @@
  *********************************************************************/
 
 import { expect } from 'chai';
+import * as fs from 'fs';
 import * as path from 'path';
 import { CdtDebugClient } from './debugClient';
 import {
@@ -22,12 +23,13 @@ import {
     fillDefaults,
 } from './utils';
 
-describe('Variables CPP Test Suite', function () {
+describe.only('Variables CPP Test Suite', function () {
     let dc: CdtDebugClient;
     let scope: Scope;
 
     const varsCppProgram = path.join(testProgramsDir, 'vars_cpp');
     const varsCppSrc = path.join(testProgramsDir, 'vars_cpp.cpp');
+    const numVars = 4; // number of variables in the main() scope of vars_cpp.cpp
 
     const lineTags = {
         'STOP HERE': 0,
@@ -66,7 +68,7 @@ describe('Variables CPP Test Suite', function () {
         expect(
             vars.body.variables.length,
             'There is a different number of variables than expected'
-        ).to.equal(3);
+        ).to.equal(numVars);
         verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, {
             hasChildren: true,
         });
@@ -121,7 +123,7 @@ describe('Variables CPP Test Suite', function () {
         expect(
             vars2.body.variables.length,
             'There is a different number of variables than expected'
-        ).to.equal(3);
+        ).to.equal(numVars);
         compareVariable(
             vars2.body.variables[0],
             vars2.body.variables[1],
@@ -166,7 +168,7 @@ describe('Variables CPP Test Suite', function () {
         expect(
             vars.body.variables.length,
             'There is a different number of variables than expected'
-        ).to.equal(3);
+        ).to.equal(numVars);
         verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, {
             hasChildren: true,
         });
@@ -216,5 +218,55 @@ describe('Variables CPP Test Suite', function () {
         verifyVariable(children.body.variables[2], 'b', 'int', '2', {
             hasMemoryReference: false,
         });
+    });
+
+    it('can evaluate anonymous and deeply nested structs and unions', async function () {
+        // assert we can see the struct
+        const vr = scope.scopes.body.scopes[0].variablesReference;
+        const vars = await dc.variablesRequest({ variablesReference: vr });
+        expect(
+            vars.body.variables.length,
+            'There is a different number of variables than expected'
+        ).to.equal(numVars);
+        verifyVariable(vars.body.variables[3], 'n', 'Nest', '{...}', {
+            hasChildren: true,
+        });
+
+        interface ExpandedVariable {
+            name: string;
+            type?: string;
+            evaluateName?: string;
+            children?: ExpandedVariable[];
+        }
+        async function expandRecursively(
+            variablesReference: number
+        ): Promise<ExpandedVariable[] | undefined> {
+            if (variablesReference <= 0) return undefined;
+            const vars = (await dc.variablesRequest({ variablesReference }))
+                .body.variables;
+            const exp = await Promise.all(
+                vars.map((v) => expandRecursively(v.variablesReference))
+            );
+            return vars.map((v, i) => {
+                const r: ExpandedVariable = {
+                    name: v.name,
+                    type: v.type,
+                    evaluateName: v.evaluateName,
+                };
+                if (exp[i]) r.children = exp[i];
+                return r;
+            });
+        }
+        const structure = await expandRecursively(
+            vars.body.variables[3].variablesReference
+        );
+        expect(structure).to.deep.equal(
+            JSON.parse(
+                fs.readFileSync(
+                    path.join(testProgramsDir, '..', 'var_nest_expected.json'),
+                    { encoding: 'utf-8' }
+                )
+            )
+        );
     });
 });


### PR DESCRIPTION
Fixes https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/230.

- There was some mix-up between varobj names (internal machine-readable identifiers) and user-visible names. The former are in field `name` in MI and not present in DAP. The latter are in field `exp` in MI and in field `name` in DAP. This only worked by accident when the two were the same, but they are not for anonymous unions or structs
- There were several things wrong with computing the `evaluateName` for anonymous unions/structs and their members. This is what is used when choosing _Copy as Expression_ from the context menu on an entry in the Variables view. I don’t know if it is used for any other purposes.

Changes are split into individual commits for easier review, they can be squashed when merging. See individual commit messages for details.