### PR TITLE
Exception when setting watchpoints with multi-location breakpoints

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -926,7 +926,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         // Filter out all watchpoints
         const existingWatchpointsList =
             fullBreakpointsList.BreakpointTable.body.filter((bp) =>
-                bp['type'].includes('watchpoint')
+                bp['type']?.includes('watchpoint')
             );
         return existingWatchpointsList;
     }


### PR DESCRIPTION
An uncaught exception occurs when trying to set a watchpoint while breakpoints with multiple locations exist. The reason is that `GDBDebugSessionBase.getWatchpointList()` expects a `type` field in the MI response to `-break-list`, but that is not present for the location lines that occur for multi-location breakpoints (their type is in their parent breakpoint line), at least with my GDB 9.2 and 11.2:

```
GDB write command: 23 -break-list
GDB result: 23 done,BreakpointTable={nr_rows="1",nr_cols="6",hdr=[{width="7",alignment="-1",col_name="number",colhdr="Num"},{width="14",alignment="-1",col_name="type",colhdr="Type"},{width="4",alignment="-1",col_name="disp",colhdr="Disp"},{width="3",alignment="-1",col_name="enabled",colhdr="Enb"},{width="18",alignment="-1",col_name="addr",colhdr="Address"},{width="40",alignment="2",col_name="what",colhdr="What"}],body=[bkpt={number="1",type="breakpoint",disp="keep",enabled="y",addr="<MULTIPLE>",times="0",original-location="-function staticfunc1"},{number="1.1",enabled="y",addr="0x0000555555555149",func="staticfunc1",file="count_other.c",fullname="/media/psf/X/projects/cdt-gdb/cdt-gdb-adapter/src/integration-tests/test-programs/count_other.c",line="1",thread-groups=["i1"]},{number="1.2",enabled="y",addr="0x0000555555555180",func="staticfunc1",file="count space.c",fullname="/media/psf/X/projects/cdt-gdb/cdt-gdb-adapter/src/integration-tests/test-programs/count space.c",line="1",thread-groups=["i1"]}]}
```

The attached commit fixes that.

#### Steps to reproduce:

1. Set a function breakpoint on `staticfunc1` (this exists in both *count space.c* and *count_other.c*).
2. Launch a debug session like this:

    ```
    {
      "type": "gdb",
      "request": "launch",
      "name": "GDB Local",
      "program": "cdt-gdb-adapter/src/integration-tests/test-programs/count",
      "debugServer": 4711,
      "verbose": true
   },
   ```
3. Pause the program. It stops in the infinite loop in `main()` in _count.c_.
4. In the _Variables_ view, right-click on local variable `count` and choose _Break on Value Change_

#### Actual Result

Output `{}` in the Debug Console (of both the client, and, if you are running the adapter in the debugger, the adapter), and no watchpoint is actually set in GDB. If you set a breakpoint in the `uncaughtException` handler in _debugAdapter.ts_, it is hit.

#### Expected Result

No error. Continuing the program makes it stop on the watchpoint immediately. Setting another watchpoint on variable `another` works too, and after that the program alternatingly stops on the two respective lines. After deleting one watchpoint, it only stops on the other line. After deleting the second watchpoint, it does not stop anymore.
