### PR TITLE
support Completion requests

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -880,7 +880,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             const effectiveColumn = this.columnStartAt1
                 ? args.column - 1
                 : args.column;
-            if (!text.startsWith('>') || args.column <= beginningOfCommand) {
+            if (
+                !text.startsWith('>') ||
+                effectiveColumn <= beginningOfCommand
+            ) {
                 // All GDB commands must start with a '>' character. If expression doesn't, return no completions.
                 this.sendResponse(response);
                 return;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -880,10 +880,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             const effectiveColumn = this.columnStartAt1
                 ? args.column - 1
                 : args.column;
-            if (
-                !text.startsWith('>') ||
-                effectiveColumn <= beginningOfCommand
-            ) {
+            if (!text.startsWith('>') || effectiveColumn < beginningOfCommand) {
                 // All GDB commands must start with a '>' character. If expression doesn't, return no completions.
                 this.sendResponse(response);
                 return;

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -888,9 +888,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 return;
             }
             const trimmedWhiteSpaceLength = args.text.length - text.length;
-            const endOfCommandToComplete =
-                effectiveColumn - trimmedWhiteSpaceLength;
-            const commandToComplete = text.slice(1, endOfCommandToComplete);
+            // Slicing from > to end of command to complete
+            const commandToComplete = args.text.slice(
+                trimmedWhiteSpaceLength + 1,
+                effectiveColumn
+            );
             const completions = await mi.sendCompletions(
                 this.gdb,
                 commandToComplete
@@ -902,7 +904,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                         length: commandToComplete.length,
                         start:
                             trimmedWhiteSpaceLength +
-                            (this.columnStartAt1 ? 2 : 1), // +1 for the '>' character
+                            (this.columnStartAt1 ? 2 : 1), // +1 for the '>' character if 0-based, +2 if 1-based
                     };
                 }),
             };

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -160,6 +160,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     // threads yet, this is the last certain value.
     protected isRunning = false;
 
+    protected columnStartAt1 = true;
     protected supportsRunInTerminalRequest = false;
     protected supportsMemoryReferences = false;
     protected supportsMemoryEvent = false;
@@ -441,6 +442,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             args.supportsRunInTerminalRequest === true;
         this.supportsMemoryReferences = args.supportsMemoryReferences === true;
         this.supportsMemoryEvent = args.supportsMemoryEvent === true;
+        this.columnStartAt1 = args.columnsStartAt1 === true;
         this.supportsGdbConsole =
             os.platform() === 'linux' && this.supportsRunInTerminalRequest;
         response.body = response.body || {};
@@ -465,6 +467,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         cap.supportsTerminateRequest = this.isRemote;
         cap.supportsDataBreakpoints = true;
         cap.supportsBreakpointLocationsRequest = true;
+        cap.supportsCompletionsRequest = true;
         cap.supportTerminateDebuggee = this.isRemote;
         cap.breakpointModes = this.getBreakpointModes();
     }
@@ -858,6 +861,66 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
         // The promise resolves when pushed resolveFunc gets called.
         return pausePromise;
+    }
+
+    protected async completionsRequest(
+        response: DebugProtocol.CompletionsResponse,
+        args: DebugProtocol.CompletionsArguments
+    ): Promise<void> {
+        try {
+            if (!this.canRequestProceed()) {
+                this.logger.verbose(
+                    'Debug adapter cannot process completions request, skipping it.'
+                );
+                this.sendResponse(response);
+                return;
+            }
+            const text = args.text.trimStart();
+            const effectiveColumn = this.columnStartAt1
+                ? args.column - 1
+                : args.column;
+            if (
+                !text.startsWith('>') ||
+                args.column <= args.text.indexOf('>') + 1
+            ) {
+                // All GDB commands must start with a '>' character. If expression doesn't, return no completions.
+                this.sendResponse(response);
+                return;
+            }
+            const trimmedWhiteSpaceLength = args.text.length - text.length;
+            const endOfCommandToComplete =
+                effectiveColumn - trimmedWhiteSpaceLength;
+            const commandToComplete = text.slice(1, endOfCommandToComplete);
+            const completions = await mi.sendCompletions(
+                this.gdb,
+                commandToComplete
+            );
+            response.body = {
+                targets: completions.matches.map((completion) => {
+                    return {
+                        label: completion,
+                        length: commandToComplete.length,
+                        start:
+                            trimmedWhiteSpaceLength +
+                            (this.columnStartAt1 ? 2 : 1), // +1 for the '>' character
+                    };
+                }),
+            };
+            this.sendResponse(response);
+        } catch (err) {
+            if (err instanceof Error && err.message.includes('complete')) {
+                response.body = {
+                    targets: [],
+                };
+                this.sendResponse(response);
+            } else {
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
+            }
+        }
     }
 
     protected async dataBreakpointInfoRequest(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -876,13 +876,11 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 return;
             }
             const text = args.text.trimStart();
+            const beginningOfCommand = args.text.indexOf('>') + 1;
             const effectiveColumn = this.columnStartAt1
                 ? args.column - 1
                 : args.column;
-            if (
-                !text.startsWith('>') ||
-                args.column <= args.text.indexOf('>') + 1
-            ) {
+            if (!text.startsWith('>') || args.column <= beginningOfCommand) {
                 // All GDB commands must start with a '>' character. If expression doesn't, return no completions.
                 this.sendResponse(response);
                 return;

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -138,7 +138,6 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         dc = new CdtDebugClient();
         await dc.start(debugServerPort);
         await dc.initializeRequest(initRequestArgs);
-        //await dc.waitForEvent('initialized');
         await dc.launchRequest(
             fillDefaults(this.currentTest, { program: evaluateProgram })
         );

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -1,0 +1,115 @@
+/*********************************************************************
+ * Copyright (c) 2026 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as path from 'path';
+import { CdtDebugClient } from './debugClient';
+import { testProgramsDir, standardBeforeEach, fillDefaults } from './utils';
+import { expect } from 'chai';
+
+describe('Miscellaneous GDB Commands Tests', function () {
+    let dc: CdtDebugClient;
+
+    const evaluateProgram = path.join(testProgramsDir, 'evaluate');
+    const evaluateSrc = path.join(testProgramsDir, 'evaluate.cpp');
+
+    beforeEach(async function () {
+        dc = await standardBeforeEach();
+        await dc.hitBreakpoint(
+            fillDefaults(this.currentTest, {
+                program: evaluateProgram,
+            }),
+            {
+                path: evaluateSrc,
+                line: 2,
+            }
+        );
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    it('should retrieve a valid list of completions for a valid command', async function () {
+        const completions: any = await dc.send('completions', {
+            text: '>pr',
+            column: 3,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: 'print',
+            length: 1,
+            start: 2,
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should retrieve a empty list for an invalid command', async function () {
+        const text = '>invalidCommand';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        expect(completions.body.targets).to.not.deep.include({
+            label: 'invalidCommand',
+            length: 0,
+            start: 0,
+        });
+    });
+
+    it('should retrieve a valid list of completions for a valid command without a complete argument', async function () {
+        const text = ' > b ma ';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: ' b main',
+            length: text.length - text.indexOf('b'),
+            start: text.indexOf('b') + 1,
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should have a starting position exactly at where the command starts', async function () {
+        const text = '   >   python-interactive';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length - 4,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: '   python-interactive',
+            length: text.length - 1 - 4 - text.indexOf('>') - 1, // as column is text.length - 4, subtract 4 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
+            start: text.indexOf('p') + 1,
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should not return completions for a command when cursor is before the > character', async function () {
+        const text = '   >   python-interactive';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.indexOf('>') - 1, // cursor is before the ">" character
+        });
+        expect(completions.body).to.be.undefined;
+    });
+
+    it('should only return completions for a command that is written before the cursor position', async function () {
+        const text = '   >   interrupt';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.indexOf('p') - 1, // cursor is before the "p" character
+        });
+        expect(completions.body.targets).to.be.an('array');
+        expect(completions.body.targets.length).to.be.greaterThan(1);
+    });
+});

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -10,7 +10,12 @@
 
 import * as path from 'path';
 import { CdtDebugClient } from './debugClient';
-import { testProgramsDir, standardBeforeEach, fillDefaults } from './utils';
+import {
+    testProgramsDir,
+    standardBeforeEach,
+    fillDefaults,
+    debugServerPort,
+} from './utils';
 import { expect } from 'chai';
 
 describe('Miscellaneous GDB Commands Tests', function () {
@@ -21,6 +26,118 @@ describe('Miscellaneous GDB Commands Tests', function () {
 
     beforeEach(async function () {
         dc = await standardBeforeEach();
+        await dc.hitBreakpoint(
+            fillDefaults(this.currentTest, {
+                program: evaluateProgram,
+            }),
+            {
+                path: evaluateSrc,
+                line: 2,
+            }
+        );
+    });
+
+    afterEach(async function () {
+        await dc.stop();
+    });
+
+    it('should retrieve a valid list of completions for a valid command', async function () {
+        const completions: any = await dc.send('completions', {
+            text: '>pr',
+            column: 3,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: 'print',
+            length: 1,
+            start: 2,
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should retrieve a empty list for an invalid command', async function () {
+        const text = '>invalidCommand';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        expect(completions.body.targets).to.not.deep.include({
+            label: 'invalidCommand',
+            length: 0,
+            start: 0,
+        });
+    });
+
+    it('should retrieve a valid list of completions for a valid command without a complete argument', async function () {
+        const text = ' > b ma';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length + 1,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: ' b main',
+            length: text.slice(text.indexOf('>') + 1, text.length).length, // everything after the ">" character should be replaced
+            start: text.indexOf('>') + 2, // vscode is 1-based, so we need to add 2 to the index of '>'
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should have a starting position exactly at where the command starts', async function () {
+        const text = '   >   python-interactive';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.length - 3,
+        });
+        expect(completions.body.targets).to.be.an('array');
+        const expectedCompletion = {
+            label: '   python-interactive',
+            length: text.slice(text.indexOf('>') + 1, text.length - 4).length, // as column is text.length - 4, subtract 4 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
+            start: text.indexOf('>') + 2,
+        };
+        expect(completions.body.targets).to.deep.include(expectedCompletion);
+    });
+
+    it('should not return completions for a command when cursor is before the > character', async function () {
+        const text = '   >   python-interactive';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.indexOf('>') - 1, // cursor is before the ">" character
+        });
+        expect(completions.body).to.be.undefined;
+    });
+
+    it('should only return completions for a command that is written before the cursor position', async function () {
+        const text = '   >   interrupt';
+        const completions: any = await dc.send('completions', {
+            text: text,
+            column: text.indexOf('p') - 1, // cursor is before the "p" character
+        });
+        expect(completions.body.targets).to.be.an('array');
+        expect(completions.body.targets.length).to.be.greaterThan(1);
+    });
+});
+
+describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', function () {
+    let dc: CdtDebugClient;
+
+    const evaluateProgram = path.join(testProgramsDir, 'evaluate');
+    const evaluateSrc = path.join(testProgramsDir, 'evaluate.cpp');
+
+    beforeEach(async function () {
+        const initRequestArgs = {
+            supportsRunInTerminalRequest: true,
+            supportsMemoryEvent: true,
+            supportsMemoryReferences: true,
+            adapterID: this['_debugType'],
+            linesStartAt1: true,
+            columnsStartAt1: false,
+            pathFormat: 'path',
+        };
+        dc = new CdtDebugClient();
+        await dc.start(debugServerPort);
+        await dc.initializeRequest(initRequestArgs);
         await dc.hitBreakpoint(
             fillDefaults(this.currentTest, {
                 program: evaluateProgram,

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -137,10 +137,12 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         };
         dc = new CdtDebugClient();
         await dc.start(debugServerPort);
+        const initializedEvent = dc.waitForEvent('initialized');
         await dc.initializeRequest(initRequestArgs);
         await dc.launchRequest(
             fillDefaults(this.currentTest, { program: evaluateProgram })
         );
+        await initializedEvent;
         await dc.setBreakpointsRequest({
             source: { path: evaluateSrc },
             lines: [2],

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -65,16 +65,16 @@ describe('Miscellaneous GDB Commands Tests', function () {
     });
 
     it('should retrieve a valid list of completions for a valid command without a complete argument', async function () {
-        const text = ' > b ma ';
+        const text = ' > b ma';
         const completions: any = await dc.send('completions', {
             text: text,
-            column: text.length,
+            column: text.length + 1,
         });
         expect(completions.body.targets).to.be.an('array');
         const expectedCompletion = {
             label: ' b main',
-            length: text.length - text.indexOf('b'),
-            start: text.indexOf('b') + 1,
+            length: text.slice(text.indexOf('>') + 1, text.length).length, // everything after the ">" character should be replaced
+            start: text.indexOf('>') + 2, // vscode is 1-based, so we need to add 2 to the index of '>'
         };
         expect(completions.body.targets).to.deep.include(expectedCompletion);
     });
@@ -83,13 +83,13 @@ describe('Miscellaneous GDB Commands Tests', function () {
         const text = '   >   python-interactive';
         const completions: any = await dc.send('completions', {
             text: text,
-            column: text.length - 4,
+            column: text.length - 3,
         });
         expect(completions.body.targets).to.be.an('array');
         const expectedCompletion = {
             label: '   python-interactive',
-            length: text.length - 1 - 4 - text.indexOf('>') - 1, // as column is text.length - 4, subtract 4 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
-            start: text.indexOf('p') + 1,
+            length: text.slice(text.indexOf('>') + 1, text.length - 4).length, // as column is text.length - 4, subtract 4 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
+            start: text.indexOf('>') + 2,
         };
         expect(completions.body.targets).to.deep.include(expectedCompletion);
     });

--- a/src/integration-tests/miscellaneous.spec.ts
+++ b/src/integration-tests/miscellaneous.spec.ts
@@ -138,15 +138,20 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         dc = new CdtDebugClient();
         await dc.start(debugServerPort);
         await dc.initializeRequest(initRequestArgs);
-        await dc.hitBreakpoint(
-            fillDefaults(this.currentTest, {
-                program: evaluateProgram,
-            }),
-            {
-                path: evaluateSrc,
-                line: 2,
-            }
+        //await dc.waitForEvent('initialized');
+        await dc.launchRequest(
+            fillDefaults(this.currentTest, { program: evaluateProgram })
         );
+        await dc.setBreakpointsRequest({
+            source: { path: evaluateSrc },
+            lines: [2],
+            breakpoints: [{ line: 2 }],
+        });
+        await dc.configurationDoneRequest();
+        await dc.assertStoppedLocation('breakpoint', {
+            path: evaluateSrc,
+            line: 2,
+        });
     });
 
     afterEach(async function () {
@@ -161,8 +166,8 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         expect(completions.body.targets).to.be.an('array');
         const expectedCompletion = {
             label: 'print',
-            length: 1,
-            start: 2,
+            length: 2,
+            start: 1,
         };
         expect(completions.body.targets).to.deep.include(expectedCompletion);
     });
@@ -191,7 +196,7 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         const expectedCompletion = {
             label: ' b main',
             length: text.slice(text.indexOf('>') + 1, text.length).length, // everything after the ">" character should be replaced
-            start: text.indexOf('>') + 2, // vscode is 1-based, so we need to add 2 to the index of '>'
+            start: text.indexOf('>') + 1,
         };
         expect(completions.body.targets).to.deep.include(expectedCompletion);
     });
@@ -205,8 +210,8 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         expect(completions.body.targets).to.be.an('array');
         const expectedCompletion = {
             label: '   python-interactive',
-            length: text.slice(text.indexOf('>') + 1, text.length - 4).length, // as column is text.length - 4, subtract 4 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
-            start: text.indexOf('>') + 2,
+            length: text.slice(text.indexOf('>') + 1, text.length - 3).length, // as column is text.length - 3, subtract 3 from the length to mimic python-intera|ctive. Everything after '>' should be replaced
+            start: text.indexOf('>') + 1,
         };
         expect(completions.body.targets).to.deep.include(expectedCompletion);
     });
@@ -224,7 +229,7 @@ describe('Miscellaneous GDB commands tests with columnStartAt1 set to false', fu
         const text = '   >   interrupt';
         const completions: any = await dc.send('completions', {
             text: text,
-            column: text.indexOf('p') - 1, // cursor is before the "p" character
+            column: text.indexOf('p') - 2, // cursor is before the "p" character
         });
         expect(completions.body.targets).to.be.an('array');
         expect(completions.body.targets.length).to.be.greaterThan(1);

--- a/src/mi/index.ts
+++ b/src/mi/index.ts
@@ -17,3 +17,4 @@ export * from './thread';
 export * from './var';
 export * from './interpreter';
 export * from './symbols';
+export * from './miscellaneous';

--- a/src/mi/miscellaneous.ts
+++ b/src/mi/miscellaneous.ts
@@ -1,0 +1,25 @@
+/*********************************************************************
+ * Copyright (c) 2026 Arm Limited and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import { IGDBBackend } from '../types/gdb';
+
+export interface MICompletion {
+    completion?: string;
+    matches: string[];
+    max_completions_reached: string;
+}
+
+export async function sendCompletions(
+    gdb: IGDBBackend,
+    command: string
+): Promise<MICompletion> {
+    const miCommand = `-complete "${command.replace(/(["\\])/g, '\\$1')}"`;
+    return gdb.sendCommand<MICompletion>(miCommand);
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/560
I added a handler for `completionsRequest` as per the MS-DAP [documentation](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Completions) and GDB/MI [documentation](https://sourceware.org/gdb/current/onlinedocs/gdb.html/GDB_002fMI-Miscellaneous-Commands.html#GDB_002fMI-Miscellaneous-Commands).

The `completion` request is called whenever users start typing in the debug console.

Note: VSCode caches the completions returned and does not call a new `completion` request unless the user closed the open list of suggestions.

Note: So far this only works for actual GDB commands starting with the `>` operator. I am planning to extend it to support simple expressions that do not have to be prepended with any operators


<img width="757" height="290" alt="image" src="https://github.com/user-attachments/assets/5511830c-e99a-447f-8ad3-9e3ff5a27108" />
