### PR TITLE
Invalidate variables after writing memory

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -3111,6 +3111,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             const hexContent = base64ToHex(data);
             await mi.sendDataWriteMemoryBytes(gdb, memoryReference, hexContent);
             this.sendResponse(response);
+            // inform to Variables view that need to refresh data on the view
+            this.sendEvent(new InvalidatedEvent(['variables']));
         } catch (err) {
             this.sendErrorResponse(
                 response,

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -181,7 +181,7 @@ describe('Memory Test Suite', function () {
         memoryReference: '&array',
     };
 
-    it('can write memory', async function () {
+    it('can write memory and invalidates variables', async function () {
         const addrOfArray = parseInt(
             (
                 await dc.evaluateRequest({
@@ -190,12 +190,22 @@ describe('Memory Test Suite', function () {
                 })
             ).body.result
         );
-        await dc.writeMemoryRequest(writeArguments);
+
+        const invalidatedEventPromise = dc.waitForEvent('invalidated');
+
+        const writeMemoryResponse = await dc.writeMemoryRequest(writeArguments);
+
+        expect(writeMemoryResponse.success).to.be.true;
+
+        const invalidatedEvent = await invalidatedEventPromise;
+
+        expect(invalidatedEvent.body.areas).to.deep.equal(['variables']);
         const memory = await dc.readMemoryRequest({
             memoryReference: '&array',
             count: 10,
             offset: 0,
         });
+
         verifyReadMemoryResponse(memory, newValue, addrOfArray);
     });
 


### PR DESCRIPTION
**Summary**
Refresh Variables views after a successful writeMemory request by emitting a DAP InvalidatedEvent.

**Problem**
The target memory is correctly updated through the DAP writeMemory request, but the Variables views can continue displaying stale values until another debugger action (such as Step, Continue, or Refresh) causes VS Code to reevaluate the variables.

This behavior can be **reproduced** through the Memory Inspector (https://github.com/eclipse-cdt-cloud/vscode-memory-inspector):

Debug the target.
Open a variable in Memory Inspector view.
Modify the memory value.
Enter the change.
The memory is updated successfully on Memory Inspector view, but the corresponding value displayed in Variables view is not updated/refreshed immediately.

**Cause**
writeMemoryRequest() writes the requested bytes to target memory and returns a successful response, but it does not notify the debug client that previously displayed variable values may no longer be valid.

As a result, VS Code keeps using a stale snapshot of variable data until another debugger action triggers reevaluation.

**Solution**
new InvalidatedEvent(['variables'])

**Test**
Update "src/integration-tests/mem.spec.ts":
Extended the existing memory write test to verify:
memory is written successfully;
an invalidated event is emitted;
the invalidated area is variables;
memory contents remain correct after the write

Dear @jonahgraham ,
Could you please help to review this fixing?
Thank you so much.